### PR TITLE
feat(gateway): 需求草稿后端 (P1 of #78)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-e2e-verification-prd-techdoc.md
+++ b/docs/superpowers/plans/2026-04-13-e2e-verification-prd-techdoc.md
@@ -1,0 +1,116 @@
+# 端到端联调验证：需求 → PRD → 技术文档
+
+- **日期**：2026-04-13
+- **范围**：需求 → PRD → 技术设计文档链路，**跳过代码生成**
+- **环境**：部署服务器 `172.29.230.21`（arcflow-server）真实环境
+- **目标**：验证每一段数据流能否自动流转，产出验证报告 + 问题清单
+
+## 1. 验证链路拆解
+
+```text
+[需求录入]           [PRD 生成]           [审批触发]          [技术文档生成]        [归档]
+Plane Issue    →    Web/NanoClaw    →    Plane 状态改    →   Dify 工作流 1   →   docs Git
+(Requirement)       生成 PRD →            为 Approved         (Opus 生成              /tech-design/
+                    写入 docs Git         → Webhook           技术设计)             + 飞书通知
+                                          触发 Gateway
+```
+
+### 链路分段
+
+| # | 段 | 触发方 | 被调方 | 产物 | 验证手段 |
+|---|---|---|---|---|---|
+| S1 | 需求录入 | 人工 | Plane | Plane Issue（需求态） | Plane UI 可见 |
+| S2 | PRD 生成 | Web/NanoClaw | Dify PRD 工作流 | `docs/prd/*.md` | Git commit 存在 |
+| S3 | PRD Review | 人工 | Plane | Issue 状态 Approved | Webhook 日志 |
+| S4 | 技术文档生成 | Plane Webhook → Gateway | Dify 工作流 1（Opus） | `docs/tech-design/*.md` | Git commit + 飞书卡片 |
+| S5 | 归档 + 通知 | Gateway | docs Git + 飞书 | Git 推送成功 + 卡片送达 | 飞书消息可见 |
+
+## 2. 前置检查
+
+- [ ] 服务器服务全部 Up：`arcflow-gateway`、`arcflow-dify-api`、`arcflow-plane-api`（已确认 2026-04-13）
+- [ ] Gateway 健康：`curl http://172.29.230.21:<port>/health`
+- [ ] Dify 四条工作流已发布（工作流 1：PRD→技术设计）
+- [ ] Plane 测试 Workspace 存在、Webhook 指向 Gateway
+- [ ] docs Git 仓库可写（Gateway 持有凭证）
+- [ ] 飞书机器人可发卡片到指定群
+- [ ] 准备一份真实测试素材（例：某小功能需求，150–300 字）
+
+## 3. 验证步骤
+
+### Step 1 — 准备测试素材
+
+创建一份真实需求描述（如"为工作流列表新增按状态筛选"），记录在验证日志中。
+
+### Step 2 — S1 需求录入
+
+在 Plane 测试工作空间创建 Issue，标签 `requirement`，贴入需求描述。
+**验收**：Issue 在 Plane UI 可见，有 ID。
+
+### Step 3 — S2 PRD 生成
+
+通过 Web 工作空间的 PRD 生成入口（或 NanoClaw）触发 PRD 工作流，传入 Plane Issue ID。
+**验收**：
+
+- `docs/prd/<date>-<slug>.md` 已生成
+- Git 有新 commit
+- PRD 结构符合模板（`docs/superpowers/specs/2026-04-02-document-templates-design.md`）
+
+### Step 4 — S3 PRD Review
+
+在 Plane 将 Issue 状态改为 `Approved`。
+**验收**：Gateway 日志收到 Plane Webhook 并识别为 approved 事件：`docker logs arcflow-gateway --tail 100`。
+
+### Step 5 — S4 技术文档生成
+
+Gateway 自动调用 Dify 工作流 1（claude-opus-4-6），生成技术设计文档。
+**验收**：
+
+- `docs/tech-design/<date>-<slug>.md` 已生成
+- Git 有新 commit
+- 文档含必要章节（架构、数据模型、接口、流程）
+- 生成耗时记录（预期 60–180s）
+
+### Step 6 — S5 归档 + 通知
+
+**验收**：
+
+- docs Git push 成功（远端可见）
+- 飞书群收到消息卡片，含 PRD/技术文档链接 + Plane Issue 链接
+- 卡片按钮可点（跳转正确）
+
+### Step 7 — 产出验证报告
+
+在 `docs/superpowers/reports/2026-04-13-e2e-verification-report.md` 记录：
+
+- 每段耗时 + 状态（✅/❌）
+- 失败段：错误日志 + 根因分析
+- 问题清单（按严重度排序，每条附对应 GitHub Issue 号）
+
+## 4. 验收标准
+
+- [ ] S1–S5 全部 ✅，或每个 ❌ 都有明确根因并开 GitHub Issue
+- [ ] 端到端耗时 < 10 分钟（不含人工审批）
+- [ ] 产出物：验证报告 + 问题清单 + 后续修复 Issue
+- [ ] 全链路无需人工干预即可从 S3（Approved）流到 S5（归档通知）
+
+## 5. 风险 & 缓解
+
+| 风险 | 缓解 |
+|---|---|
+| Dify 工作流 Prompt 对真实素材效果不达标 | 记录原始 Prompt/输出；不达标开 Issue 迭代 Prompt，不阻塞联调 |
+| Plane Webhook 漏发/延迟 | `docker logs arcflow-plane-api` + Gateway 端幂等日志定位 |
+| docs Git 冲突/push 失败 | 测试前清理测试分支；Gateway 采用 rebase 策略 |
+| 飞书私有部署 API 不兼容 | `FEISHU_BASE_URL` 已配置 xfchat.iflytek.com，先小流量测 |
+| Opus 生成超时 | Dify 端超时兜底；记录超时即判 ❌，开 Issue |
+
+## 6. 非目标
+
+- ❌ 第二/第三段：技术文档 → OpenAPI → 代码生成（后续开发）
+- ❌ Figma MCP / UI 代码生成
+- ❌ CI/CD Bug 回流
+- ❌ Dify Prompt 大幅调优（本次只记录，不改）
+
+## 7. 后续
+
+- 根据验证报告开 GitHub Issues 跟踪修复
+- 下一阶段：技术文档 → OpenAPI 段落联调

--- a/docs/superpowers/specs/2026-04-13-requirement-to-prd-redesign.md
+++ b/docs/superpowers/specs/2026-04-13-requirement-to-prd-redesign.md
@@ -1,0 +1,275 @@
+# 需求对话化 & PRD Review 流程重设计
+
+- **日期**：2026-04-13
+- **版本**：v1.0
+- **范围**：Stage 0 需求录入 → Stage 2 PRD 审批，改为对话驱动
+- **不涉及**：Stage 3 之后（技术设计之后复用现有链路），代码生成
+
+---
+
+## 1. 动机
+
+当前流程要求 PM 先在 Plane 手动建 Issue，再单独触发 PRD 生成，两个步骤分离且 Plane 操作对 PM 不友好。
+
+目标：**PM 只和 Web AI 对话，系统自动产出 Plane Issue + PRD 草稿**，人工门禁后进入技术设计阶段。
+
+---
+
+## 2. 新流程
+
+```text
+┌─────────────────────────────────────────────────────────┐
+│  Stage A: 需求对话                                       │
+│  PM → Web「AI 需求对话」→ Dify chatflow                  │
+│  多轮追问 → 产出 Issue 标题/描述 + PRD 草稿              │
+│  └─ 存 Gateway SQLite（草稿态，不 commit）               │
+└─────────────────────────────────────────────────────────┘
+                          ↓
+┌─────────────────────────────────────────────────────────┐
+│  Stage B: 草稿通知                                       │
+│  Gateway 发飞书卡片「PRD 草稿就绪，请 Review」            │
+│  按钮：查看详情（跳 Web） | 快速通过 | 快速驳回          │
+└─────────────────────────────────────────────────────────┘
+                          ↓
+┌─────────────────────────────────────────────────────────┐
+│  Stage C: PM Review（Web / 飞书 双通道）                 │
+│  Web：左对话区 | 右 Markdown 编辑/预览 tab               │
+│    • 继续对话让 AI 改 → 草稿更新                         │
+│    • 手动编辑 Markdown → 草稿更新                        │
+│    • 点「提交审批」→ 走 Stage D                          │
+│  飞书：卡片上「快速通过」→ 走 Stage D                    │
+└─────────────────────────────────────────────────────────┘
+                          ↓
+┌─────────────────────────────────────────────────────────┐
+│  Stage D: 审批落地（Gateway 原子操作）                   │
+│  1. 在 Plane 创建 Issue（标题/描述来自草稿）             │
+│  2. 将 PRD commit 到 docs git                            │
+│  3. 将 Plane Issue 状态改为 Approved                     │
+│  4. Plane Webhook 触发现有 flowPrdToTech（技术设计+OpenAPI）│
+│  5. 技术设计完成 → 现有飞书「技术 Review」卡片通知研发    │
+└─────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. 数据模型
+
+### 新表 `requirement_drafts`
+
+| 字段 | 类型 | 说明 |
+|---|---|---|
+| id | INTEGER PK | 草稿 ID |
+| workspace_id | TEXT | 所属工作空间 |
+| creator_id | TEXT | PM 用户 ID |
+| status | TEXT | `drafting` / `review` / `approved` / `rejected` / `abandoned` |
+| issue_title | TEXT | AI 生成的 Issue 标题 |
+| issue_description | TEXT | AI 生成的 Issue 描述（Markdown，作为 Plane Issue 内容） |
+| prd_content | TEXT | PRD 正文（Markdown） |
+| prd_slug | TEXT | 文件名 slug，用于 `docs/prd/YYYY-MM/<slug>.md` |
+| dify_conversation_id | TEXT | Dify 对话 ID（继续对话用） |
+| plane_issue_id | TEXT | approved 后回填 |
+| prd_git_path | TEXT | commit 后回填 |
+| feishu_chat_id | TEXT | 通知群 |
+| feishu_card_id | TEXT | 卡片 ID（便于更新卡片状态） |
+| created_at / updated_at / approved_at | TIMESTAMP | |
+
+### 状态机
+
+```text
+drafting ──对话/编辑──▶ drafting
+drafting ──「完成草稿」──▶ review
+review   ──对话/编辑──▶ review   (内容变化但不回退状态)
+review   ──「提交审批」──▶ approved （不可逆，触发 Stage D）
+review   ──「驳回」──▶ drafting
+review   ──「放弃」──▶ abandoned
+```
+
+---
+
+## 4. 接口设计
+
+### Web → Gateway
+
+| 接口 | 说明 |
+|---|---|
+| `POST /api/requirement/draft` | 新建草稿（空），返回 draft_id |
+| `POST /api/requirement/:id/chat` | SSE 流：PM 输入 → Dify chatflow → 流式回答 + 结构化产物（Issue + PRD） |
+| `GET /api/requirement/:id` | 读草稿（含当前 Issue 标题/描述 + PRD） |
+| `PATCH /api/requirement/:id` | 手动编辑（覆盖 issue_title/issue_description/prd_content） |
+| `POST /api/requirement/:id/finalize` | drafting → review：AI 对 PRD 做一次收尾整理，发飞书通知 |
+| `POST /api/requirement/:id/approve` | review → approved：执行 Stage D 原子操作 |
+| `POST /api/requirement/:id/reject` | review → drafting：记录驳回理由 |
+| `GET /api/requirement?workspace_id=xxx` | 列表（支持状态过滤） |
+
+### 飞书回调
+
+复用现有 `POST /webhook/feishu`，新增 action：
+
+- `requirement_approve`（卡片上「快速通过」）
+- `requirement_reject`（卡片上「快速驳回」）
+
+---
+
+## 5. Dify 工作流改造
+
+### 新 chatflow：「需求对话 → Issue + PRD」
+
+**输入**：
+
+- `user_message`：PM 本轮输入
+- `conversation_id`：继续对话用
+- `rag_workspace`：RAG 检索范围（当前 workspace 的 PRD 历史）
+
+**多轮策略**（参考 CLAUDE.md 规范）：
+
+1. 首轮：询问需求核心目标 + 用户场景
+2. 次轮：追问边界、验收标准、优先级
+3. 可选轮：澄清技术约束、依赖
+
+**输出（结构化，前端解析）**：
+
+```json
+{
+  "reply": "文本回复（展示在对话区）",
+  "ready": false,
+  "draft": {
+    "issue_title": "...",
+    "issue_description": "...（Markdown，作为 Plane Issue 内容）",
+    "prd_content": "...（Markdown，符合 PRD 模板）",
+    "prd_slug": "feature-name"
+  }
+}
+```
+
+AI 判断信息足够时 `ready = true`，前端据此启用「完成草稿」按钮。
+
+---
+
+## 6. Web UI 改动
+
+### 入口
+
+工作空间首页 / 对话历史页新增「新建需求」按钮 → 跳「AI 需求对话」页。
+
+### 需求对话页布局
+
+```text
+┌──────────────────────────┬────────────────────────────┐
+│  AI 对话区（左 50%）      │  草稿预览区（右 50%）       │
+│  ┌────────────────────┐  │  Tab: [PRD] [Issue 预览]    │
+│  │ 历史消息            │  │  ┌────────────────────┐    │
+│  │ ...                │  │  │ Markdown 编辑/预览  │    │
+│  │                    │  │  │ （复用现有组件）     │    │
+│  └────────────────────┘  │  └────────────────────┘    │
+│  [输入框] [发送]          │  [完成草稿] [手动保存]      │
+└──────────────────────────┴────────────────────────────┘
+```
+
+### Review 页
+
+同布局，右上角新增：
+
+- `[提交审批]`（主按钮，status=review 时可用）
+- `[驳回回草稿]`
+
+进入 approved 后页面锁定只读，显示 Plane Issue 链接 + PRD git 路径 + 技术设计进度。
+
+---
+
+## 7. 飞书卡片
+
+### 新模板：「PRD Review」
+
+```text
+📋 需求 PRD 草稿就绪
+━━━━━━━━━━━━━━━━━
+标题：工作流列表按状态筛选
+创建者：张三
+摘要：（AI 生成的 1-2 句摘要）
+
+[ 📖 查看详情 ]  ← 跳 Web Review 页
+[ ✅ 快速通过 ]  [ ❌ 驳回 ]
+```
+
+复用现有「技术 Review」卡片模板框架，只改文案和回调 action。
+
+---
+
+## 8. Stage D：审批原子操作
+
+顺序执行（任一步失败回滚已做操作 + 通知 PM）：
+
+1. **Plane 建 Issue**（`planeService.createIssue`）
+   - 标题/描述来自草稿
+   - 初始状态：`Backlog`
+2. **Git commit PRD**（`git.writeAndPush`）
+   - 路径 `docs/prd/YYYY-MM/<slug>.md`
+3. **回填草稿**：`plane_issue_id` + `prd_git_path` + `status=approved`
+4. **Plane 改状态**为 `Approved`（`planeService.updateIssueState`）
+5. 依赖现有 Webhook：Plane → Gateway → `flowPrdToTech`（**零改动**）
+6. 更新飞书卡片显示「✅ 已通过，技术设计生成中…」
+
+---
+
+## 9. 改动清单
+
+| 模块 | 文件 | 改动类型 |
+|---|---|---|
+| Gateway | `src/db/schema.ts` | 新增 `requirement_drafts` 表迁移 |
+| Gateway | `src/db/queries.ts` | 新增 draft CRUD |
+| Gateway | `src/services/requirement.ts` | 新文件：草稿管理 + finalize + approve |
+| Gateway | `src/services/dify.ts` | 新增 `streamRequirementChatflow` |
+| Gateway | `src/services/plane.ts` | 确保 `createIssue` + `updateIssueState` 可用 |
+| Gateway | `src/services/feishu.ts` | 新增 PRD Review 卡片模板 |
+| Gateway | `src/routes/api.ts` | 新增 `/api/requirement/*` 路由组 |
+| Gateway | `src/routes/webhook.ts` | 飞书回调支持 requirement_approve/reject |
+| Gateway | `src/types/index.ts` | 新增 RequirementDraft 类型 |
+| Web | `src/views/RequirementChat.vue` | 新页面：对话 + 预览布局 |
+| Web | `src/views/RequirementReview.vue` | 或合并到上页按状态切换 |
+| Web | `src/stores/requirement.ts` | Pinia store |
+| Web | `src/api/requirement.ts` | API client |
+| Web | 路由 + 菜单 | 新增入口 |
+| Dify | 需求对话 chatflow | 在 Dify 控制台建，填 `DIFY_REQUIREMENT_CHAT_API_KEY` |
+| 配置 | `.env` | 新增 `DIFY_REQUIREMENT_CHAT_API_KEY`、确保 `PLANE_APPROVED_STATE_ID` 非空 |
+
+**现有 `POST /api/prd/chat` 的归宿**：保留但标记 deprecated，留作兼容；新流程全走 `/api/requirement/*`。
+
+---
+
+## 10. 分期实施（建议拆 PR）
+
+| Phase | 内容 | 可独立交付 |
+|---|---|---|
+| P1 | Gateway 数据模型 + 草稿 CRUD + Dify chatflow 接入 | ✅ 后端测试可跑 |
+| P2 | Web 对话页（左对话右预览）+ 手动编辑 | ✅ 功能可用 |
+| P3 | finalize + 飞书 PRD Review 卡片 | ✅ 通知链路打通 |
+| P4 | approve 原子操作（建 Issue + commit + 改状态） | ✅ 触发技术设计 |
+| P5 | 端到端联调 + 验证报告 | ✅ 全链路打通 |
+
+---
+
+## 11. 验收标准
+
+- [ ] PM 在 Web 全程不进 Plane 也能完成需求录入
+- [ ] 对话 → 草稿 → Review → 通过，四个阶段飞书通知都能收到
+- [ ] 通过后 `docs/prd/` 有新 commit + Plane 有新 Issue（状态 Approved）
+- [ ] 现有 Webhook → 技术设计自动触发（不回归）
+- [ ] 草稿期中断（关浏览器）能恢复
+- [ ] 飞书卡片「快速通过」等价 Web「提交审批」
+
+---
+
+## 12. 非目标 / 延后
+
+- ❌ 代码生成（Stage 5+）
+- ❌ 多 PM 协同编辑同一草稿（单用户独占）
+- ❌ 历史版本比对（只留最终版）
+- ❌ 语音/图片输入（只支持文本）
+
+---
+
+## 13. 开放问题
+
+- 需求对话的 RAG 知识范围：只搜本 workspace 的 PRD，还是跨 workspace？→ **默认本 workspace，可配置**
+- 草稿过期策略：>30 天未操作自动归档为 abandoned？→ **P5 再定**
+- Plane Issue 的 Project 如何选定：Workspace 级配置 `default_plane_project_id`

--- a/packages/gateway/src/config.ts
+++ b/packages/gateway/src/config.ts
@@ -43,6 +43,9 @@ export interface Config {
   // PRD 生成
   difyPrdGenApiKey: string;
 
+  // 需求对话草稿
+  difyRequirementChatApiKey: string;
+
   // RAG 知识库问答
   difyRagApiKey: string;
 
@@ -108,6 +111,8 @@ export function getConfig(): Config {
     wikijsApiKey: process.env.WIKIJS_API_KEY ?? "",
 
     difyPrdGenApiKey: process.env.DIFY_PRD_GEN_API_KEY ?? process.env.DIFY_API_KEY ?? "",
+
+    difyRequirementChatApiKey: process.env.DIFY_REQUIREMENT_CHAT_API_KEY ?? "",
 
     difyRagApiKey: process.env.DIFY_RAG_API_KEY ?? process.env.DIFY_API_KEY ?? "",
 

--- a/packages/gateway/src/db/queries.test.ts
+++ b/packages/gateway/src/db/queries.test.ts
@@ -14,6 +14,12 @@ import {
   updateBugFixStatus,
   recordWebhookLog,
   listWebhookLogs,
+  createRequirementDraft,
+  getRequirementDraft,
+  listRequirementDrafts,
+  updateRequirementDraft,
+  upsertUser,
+  createWorkspace,
 } from "./queries";
 
 describe("workflow_execution", () => {
@@ -254,5 +260,163 @@ describe("bug_fix_retry", () => {
   it("get non-existent bug fix retry returns null", () => {
     const retry = getBugFixRetry("ISSUE-NONEXIST");
     expect(retry).toBeNull();
+  });
+});
+
+describe("requirement_drafts", () => {
+  let workspaceId: number;
+  let userId: number;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    getDb();
+    const ws = createWorkspace({ name: "ReqWS", slug: `req-ws-${Date.now()}` });
+    workspaceId = ws.id;
+    const user = upsertUser({ feishu_user_id: `req-user-${Date.now()}`, name: "Req User" });
+    userId = user.id;
+  });
+
+  afterEach(() => {
+    closeDb();
+  });
+
+  it("creates a draft with defaults", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    expect(draft.id).toBeGreaterThan(0);
+    expect(draft.workspace_id).toBe(workspaceId);
+    expect(draft.creator_id).toBe(userId);
+    expect(draft.status).toBe("drafting");
+    expect(draft.issue_title).toBe("");
+    expect(draft.issue_description).toBe("");
+    expect(draft.prd_content).toBe("");
+    expect(draft.prd_slug).toBeNull();
+    expect(draft.dify_conversation_id).toBeNull();
+    expect(draft.feishu_chat_id).toBeNull();
+    expect(draft.approved_at).toBeNull();
+    expect(draft.created_at).toBeTruthy();
+    expect(draft.updated_at).toBeTruthy();
+  });
+
+  it("creates a draft with optional fields", () => {
+    const draft = createRequirementDraft({
+      workspace_id: workspaceId,
+      creator_id: userId,
+      feishu_chat_id: "chat-123",
+      dify_conversation_id: "dify-conv-456",
+    });
+    expect(draft.feishu_chat_id).toBe("chat-123");
+    expect(draft.dify_conversation_id).toBe("dify-conv-456");
+  });
+
+  it("gets draft by id", () => {
+    const created = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    const fetched = getRequirementDraft(created.id);
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(created.id);
+  });
+
+  it("returns null for non-existent draft", () => {
+    expect(getRequirementDraft(999999)).toBeNull();
+  });
+
+  it("lists drafts by workspace_id", () => {
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+
+    const drafts = listRequirementDrafts({ workspace_id: workspaceId });
+    expect(drafts.length).toBe(2);
+  });
+
+  it("lists drafts with status filter", () => {
+    const d1 = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    updateRequirementDraft(d1.id, { status: "review" });
+
+    const drafting = listRequirementDrafts({ workspace_id: workspaceId, status: "drafting" });
+    expect(drafting.length).toBe(1);
+
+    const review = listRequirementDrafts({ workspace_id: workspaceId, status: "review" });
+    expect(review.length).toBe(1);
+  });
+
+  it("lists drafts with limit", () => {
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+
+    const limited = listRequirementDrafts({ workspace_id: workspaceId, limit: 2 });
+    expect(limited.length).toBe(2);
+  });
+
+  it("updates draft fields", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    const ok = updateRequirementDraft(draft.id, {
+      issue_title: "新功能需求",
+      issue_description: "详细描述",
+      prd_content: "# PRD\n内容",
+      prd_slug: "new-feature-req",
+      dify_conversation_id: "conv-789",
+    });
+    expect(ok).toBe(true);
+
+    const updated = getRequirementDraft(draft.id);
+    expect(updated!.issue_title).toBe("新功能需求");
+    expect(updated!.issue_description).toBe("详细描述");
+    expect(updated!.prd_content).toBe("# PRD\n内容");
+    expect(updated!.prd_slug).toBe("new-feature-req");
+    expect(updated!.dify_conversation_id).toBe("conv-789");
+  });
+
+  it("updates status and sets approved_at when status is approved", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    updateRequirementDraft(draft.id, { status: "approved" });
+
+    const updated = getRequirementDraft(draft.id);
+    expect(updated!.status).toBe("approved");
+    expect(updated!.approved_at).not.toBeNull();
+  });
+
+  it("does not set approved_at for non-approved status", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    updateRequirementDraft(draft.id, { status: "review" });
+
+    const updated = getRequirementDraft(draft.id);
+    expect(updated!.status).toBe("review");
+    expect(updated!.approved_at).toBeNull();
+  });
+
+  it("returns false when updating non-existent draft", () => {
+    const ok = updateRequirementDraft(999999, { issue_title: "x" });
+    expect(ok).toBe(false);
+  });
+
+  it("returns false when patch is empty", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    const ok = updateRequirementDraft(draft.id, {});
+    expect(ok).toBe(false);
+  });
+
+  it("filters drafts by creator_id", () => {
+    const user2 = upsertUser({ feishu_user_id: `req-user2-${Date.now()}`, name: "User 2" });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    createRequirementDraft({ workspace_id: workspaceId, creator_id: user2.id });
+
+    const mine = listRequirementDrafts({ creator_id: userId });
+    expect(mine.length).toBe(1);
+    expect(mine[0].creator_id).toBe(userId);
+  });
+
+  it("updates plane_issue_id and prd_git_path", () => {
+    const draft = createRequirementDraft({ workspace_id: workspaceId, creator_id: userId });
+    updateRequirementDraft(draft.id, {
+      plane_issue_id: "PLANE-123",
+      prd_git_path: "prd/2026-04/new-feature.md",
+      feishu_card_id: "card-abc",
+    });
+
+    const updated = getRequirementDraft(draft.id);
+    expect(updated!.plane_issue_id).toBe("PLANE-123");
+    expect(updated!.prd_git_path).toBe("prd/2026-04/new-feature.md");
+    expect(updated!.feishu_card_id).toBe("card-abc");
   });
 });

--- a/packages/gateway/src/db/queries.ts
+++ b/packages/gateway/src/db/queries.ts
@@ -11,6 +11,8 @@ import type {
   Conversation,
   Message,
   Workspace,
+  RequirementDraft,
+  RequirementDraftStatus,
 } from "../types";
 
 // ─── workflow_execution ────────────────────────────────────────────────────────
@@ -477,4 +479,131 @@ export function createMessage(
   );
   const row = db.query("SELECT last_insert_rowid() as id").get() as { id: number };
   return db.query("SELECT * FROM messages WHERE id = ?").get(row.id) as Message;
+}
+
+// ─── requirement_drafts ───────────────────────────────────────────────────────
+
+export function createRequirementDraft(input: {
+  workspace_id: number;
+  creator_id: number;
+  feishu_chat_id?: string;
+  dify_conversation_id?: string;
+}): RequirementDraft {
+  const db = getDb();
+  db.query(
+    `INSERT INTO requirement_drafts (workspace_id, creator_id, feishu_chat_id, dify_conversation_id)
+     VALUES (?, ?, ?, ?)`,
+  ).run(
+    input.workspace_id,
+    input.creator_id,
+    input.feishu_chat_id ?? null,
+    input.dify_conversation_id ?? null,
+  );
+  const { id } = db.query("SELECT last_insert_rowid() as id").get() as { id: number };
+  return db.query("SELECT * FROM requirement_drafts WHERE id = ?").get(id) as RequirementDraft;
+}
+
+export function getRequirementDraft(id: number): RequirementDraft | null {
+  const db = getDb();
+  return db
+    .query("SELECT * FROM requirement_drafts WHERE id = ?")
+    .get(id) as RequirementDraft | null;
+}
+
+export function listRequirementDrafts(filters: {
+  workspace_id?: number;
+  creator_id?: number;
+  status?: RequirementDraftStatus;
+  limit?: number;
+}): RequirementDraft[] {
+  const db = getDb();
+  const limit = filters.limit ?? 20;
+  const conditions: string[] = [];
+  const values: (string | number)[] = [];
+
+  if (filters.workspace_id !== undefined) {
+    conditions.push("workspace_id = ?");
+    values.push(filters.workspace_id);
+  }
+  if (filters.creator_id !== undefined) {
+    conditions.push("creator_id = ?");
+    values.push(filters.creator_id);
+  }
+  if (filters.status !== undefined) {
+    conditions.push("status = ?");
+    values.push(filters.status);
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+  return db
+    .query(`SELECT * FROM requirement_drafts ${where} ORDER BY updated_at DESC LIMIT ?`)
+    .all(...values, limit) as RequirementDraft[];
+}
+
+export function updateRequirementDraft(
+  id: number,
+  patch: {
+    issue_title?: string;
+    issue_description?: string;
+    prd_content?: string;
+    prd_slug?: string;
+    dify_conversation_id?: string;
+    status?: RequirementDraftStatus;
+    feishu_card_id?: string;
+    plane_issue_id?: string;
+    prd_git_path?: string;
+  },
+): boolean {
+  const db = getDb();
+  const sets: string[] = [];
+  const values: unknown[] = [];
+
+  if (patch.issue_title !== undefined) {
+    sets.push("issue_title = ?");
+    values.push(patch.issue_title);
+  }
+  if (patch.issue_description !== undefined) {
+    sets.push("issue_description = ?");
+    values.push(patch.issue_description);
+  }
+  if (patch.prd_content !== undefined) {
+    sets.push("prd_content = ?");
+    values.push(patch.prd_content);
+  }
+  if (patch.prd_slug !== undefined) {
+    sets.push("prd_slug = ?");
+    values.push(patch.prd_slug);
+  }
+  if (patch.dify_conversation_id !== undefined) {
+    sets.push("dify_conversation_id = ?");
+    values.push(patch.dify_conversation_id);
+  }
+  if (patch.status !== undefined) {
+    sets.push("status = ?");
+    values.push(patch.status);
+    if (patch.status === "approved") {
+      sets.push("approved_at = datetime('now')");
+    }
+  }
+  if (patch.feishu_card_id !== undefined) {
+    sets.push("feishu_card_id = ?");
+    values.push(patch.feishu_card_id);
+  }
+  if (patch.plane_issue_id !== undefined) {
+    sets.push("plane_issue_id = ?");
+    values.push(patch.plane_issue_id);
+  }
+  if (patch.prd_git_path !== undefined) {
+    sets.push("prd_git_path = ?");
+    values.push(patch.prd_git_path);
+  }
+
+  if (sets.length === 0) return false;
+  sets.push("updated_at = datetime('now')");
+  values.push(id);
+
+  const result = db
+    .query(`UPDATE requirement_drafts SET ${sets.join(", ")} WHERE id = ?`)
+    .run(...values);
+  return result.changes > 0;
 }

--- a/packages/gateway/src/db/schema.sql
+++ b/packages/gateway/src/db/schema.sql
@@ -95,3 +95,24 @@ CREATE TABLE IF NOT EXISTS messages (
 
 CREATE INDEX IF NOT EXISTS idx_conversations_user ON conversations(user_id, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_messages_conv ON messages(conversation_id, created_at);
+
+CREATE TABLE IF NOT EXISTS requirement_drafts (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workspace_id INTEGER NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  creator_id INTEGER NOT NULL REFERENCES users(id),
+  status TEXT NOT NULL DEFAULT 'drafting',
+  issue_title TEXT NOT NULL DEFAULT '',
+  issue_description TEXT NOT NULL DEFAULT '',
+  prd_content TEXT NOT NULL DEFAULT '',
+  prd_slug TEXT,
+  dify_conversation_id TEXT,
+  plane_issue_id TEXT,
+  prd_git_path TEXT,
+  feishu_chat_id TEXT,
+  feishu_card_id TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  approved_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_requirement_drafts_workspace ON requirement_drafts(workspace_id, status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_requirement_drafts_creator ON requirement_drafts(creator_id, updated_at DESC);

--- a/packages/gateway/src/routes/api.ts
+++ b/packages/gateway/src/routes/api.ts
@@ -17,7 +17,14 @@ import {
 } from "../services/prd";
 import { queryKnowledgeBase } from "../services/dify";
 import { syncGitToDify } from "../services/rag-sync";
-import type { TriggerWorkflowRequest, WorkflowType, WorkflowStatus, WebhookSource } from "../types";
+import { createDraft, chatDraft, patchDraft, getDraft, listDrafts } from "../services/requirement";
+import type {
+  TriggerWorkflowRequest,
+  WorkflowType,
+  WorkflowStatus,
+  WebhookSource,
+  RequirementDraftStatus,
+} from "../types";
 
 export const apiRoutes = new Hono();
 
@@ -226,4 +233,99 @@ apiRoutes.post("/rag/sync", async (c) => {
       500,
     );
   }
+});
+
+// ─── Requirement Draft Routes ──────────────────────────────────────────────────
+
+apiRoutes.post("/requirement/draft", async (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const body = await c.req.json<{ workspace_id: number; feishu_chat_id?: string }>();
+  if (!body.workspace_id) {
+    return c.json({ error: "workspace_id is required" }, 400);
+  }
+  if (!getWorkspace(body.workspace_id)) {
+    return c.json({ error: `workspace ${body.workspace_id} not found` }, 404);
+  }
+
+  const draft = createDraft({
+    workspaceId: body.workspace_id,
+    creatorId: userId,
+    feishuChatId: body.feishu_chat_id,
+  });
+  return c.json(draft, 201);
+});
+
+apiRoutes.get("/requirement/:id", (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = Number(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
+
+  const { draft, error } = getDraft(id, userId);
+  if (error) return c.json({ error }, draft === null ? 404 : 403);
+  return c.json(draft);
+});
+
+apiRoutes.get("/requirement", (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const workspaceId = c.req.query("workspace_id") ? Number(c.req.query("workspace_id")) : undefined;
+  const status = c.req.query("status") as RequirementDraftStatus | undefined;
+  const limit = Number(c.req.query("limit")) || 20;
+
+  const drafts = listDrafts({ workspaceId, userId, status, limit });
+  return c.json({ data: drafts, total: drafts.length });
+});
+
+apiRoutes.patch("/requirement/:id", async (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = Number(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
+
+  const body = await c.req.json<{
+    issue_title?: string;
+    issue_description?: string;
+    prd_content?: string;
+  }>();
+
+  const { ok, error } = patchDraft({ draftId: id, userId, patch: body });
+  if (!ok) {
+    return c.json({ error }, error === "草稿不存在" ? 404 : 403);
+  }
+  return c.json({ ok: true });
+});
+
+apiRoutes.post("/requirement/:id/chat", async (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = Number(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
+
+  const body = await c.req.json<{ message: string }>();
+  if (!body.message?.trim()) {
+    return c.json({ error: "message is required" }, 400);
+  }
+
+  return streamSSE(c, async (stream) => {
+    for await (const { event, data } of chatDraft({ draftId: id, userId, message: body.message })) {
+      await stream.writeSSE({ event, data });
+    }
+  });
 });

--- a/packages/gateway/src/services/dify.ts
+++ b/packages/gateway/src/services/dify.ts
@@ -1,4 +1,6 @@
 import { getConfig } from "../config";
+import { parseDifySSEChunk } from "./prd";
+import type { DifySSEChunk } from "./prd";
 
 interface DifyWorkflowResponse {
   data: {
@@ -115,4 +117,63 @@ export async function queryKnowledgeBase(
 
   const json = (await res.json()) as { answer: string; conversation_id: string };
   return { answer: json.answer, conversation_id: json.conversation_id };
+}
+
+export async function* streamRequirementChatflow(params: {
+  query: string;
+  conversationId?: string;
+  userId: string;
+  workspaceId: number;
+  apiKey: string;
+  baseUrl: string;
+}): AsyncGenerator<DifySSEChunk> {
+  const { query, conversationId, userId, apiKey, baseUrl } = params;
+
+  const response = await fetch(`${baseUrl}/v1/chat-messages`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      query,
+      conversation_id: conversationId ?? "",
+      response_mode: "streaming",
+      user: userId,
+      inputs: {},
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Dify Requirement Chat API error: ${response.status} ${await response.text()}`);
+  }
+
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const chunk = parseDifySSEChunk(trimmed);
+      if (chunk && chunk.event !== "ping") {
+        yield chunk;
+      }
+    }
+  }
+
+  if (buffer.trim()) {
+    const chunk = parseDifySSEChunk(buffer.trim());
+    if (chunk && chunk.event !== "ping") {
+      yield chunk;
+    }
+  }
 }

--- a/packages/gateway/src/services/git.test.ts
+++ b/packages/gateway/src/services/git.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it, mock, beforeEach } from "bun:test";
 import { join } from "path";
 import * as realFs from "fs";
 
+// Capture real fs functions before mock.module("fs") replaces the module bindings.
+// bun updates the live namespace object when mock.module is called, so realFs.readFileSync
+// would point to the mock after mock.module("fs") executes — causing infinite recursion.
+const _realReadFileSync = realFs.readFileSync.bind(realFs);
+const _realExistsSync = realFs.existsSync.bind(realFs);
+
 // --- Mock simple-git ---
 const gitMethods = {
   fetch: mock(() => Promise.resolve()),
@@ -34,13 +40,13 @@ const renameSyncMock = mock(() => undefined);
 mock.module("fs", () => ({
   ...realFs,
   existsSync: (path: string) => {
-    if (typeof path === "string" && path.endsWith(".sql")) return realFs.existsSync(path);
+    if (typeof path === "string" && path.endsWith(".sql")) return _realExistsSync(path);
     return existsSyncReturn;
   },
   mkdirSync: mkdirSyncMock,
   readFileSync: (path: string, ...args: unknown[]) => {
     if (typeof path === "string" && path.endsWith(".sql"))
-      return realFs.readFileSync(path, ...(args as [BufferEncoding]));
+      return _realReadFileSync(path, ...(args as [BufferEncoding]));
     return readFileSyncMock(path, ...args);
   },
   writeFileSync: writeFileSyncMock,

--- a/packages/gateway/src/services/requirement.test.ts
+++ b/packages/gateway/src/services/requirement.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, mock } from "bun:test";
+import { getDb, closeDb } from "../db";
+import {
+  upsertUser,
+  createWorkspace,
+  addWorkspaceMember,
+  updateRequirementDraft,
+} from "../db/queries";
+import {
+  extractRequirementDraft,
+  containsRequirementMarker,
+  createDraft,
+  patchDraft,
+  getDraft,
+  listDrafts,
+} from "./requirement";
+
+// Pre-initialize DB before any git.test.ts fs mock can interfere with schema reads.
+// This ensures schema.sql is loaded using the real fs, not the mocked version.
+beforeAll(() => {
+  process.env.NODE_ENV = "test";
+  getDb();
+});
+
+describe("extractRequirementDraft", () => {
+  it("extracts structured draft from answer", () => {
+    // prd_content 在 JSON 字符串值中用 \\n 转义（合法 JSON），而非裸换行
+    const jsonPayload = JSON.stringify({
+      reply: "草稿已生成",
+      ready: true,
+      draft: {
+        issue_title: "手机登录",
+        issue_description: "支持手机验证码登录",
+        prd_content: "# PRD\n## 功能描述",
+        prd_slug: "mobile-login",
+      },
+    });
+    const answer = `好的，我已整理好需求草稿。\n<REQUIREMENT_DRAFT>${jsonPayload}</REQUIREMENT_DRAFT>`;
+
+    const result = extractRequirementDraft(answer);
+    expect(result).not.toBeNull();
+    expect(result!.reply).toBe("草稿已生成");
+    expect(result!.ready).toBe(true);
+    expect(result!.draft).not.toBeUndefined();
+    expect(result!.draft!.issue_title).toBe("手机登录");
+    expect(result!.draft!.issue_description).toBe("支持手机验证码登录");
+    expect(result!.draft!.prd_content).toContain("# PRD");
+    expect(result!.draft!.prd_slug).toBe("mobile-login");
+  });
+
+  it("extracts draft without prd_slug", () => {
+    const jsonPayload = JSON.stringify({
+      reply: "继续对话",
+      ready: false,
+      draft: { issue_title: "标题", issue_description: "描述", prd_content: "内容" },
+    });
+    const answer = `<REQUIREMENT_DRAFT>${jsonPayload}</REQUIREMENT_DRAFT>`;
+    const result = extractRequirementDraft(answer);
+    expect(result).not.toBeNull();
+    expect(result!.ready).toBe(false);
+    expect(result!.draft!.prd_slug).toBeUndefined();
+  });
+
+  it("returns null when no marker found", () => {
+    expect(extractRequirementDraft("普通对话回复，没有结构化输出")).toBeNull();
+  });
+
+  it("returns null for malformed JSON", () => {
+    const answer = "<REQUIREMENT_DRAFT>{invalid json}</REQUIREMENT_DRAFT>";
+    expect(extractRequirementDraft(answer)).toBeNull();
+  });
+
+  it("returns null when end marker is missing", () => {
+    const answer = '<REQUIREMENT_DRAFT>{"reply":"test","ready":false}';
+    expect(extractRequirementDraft(answer)).toBeNull();
+  });
+
+  it("extracts draft without draft field (reply only)", () => {
+    const answer = `<REQUIREMENT_DRAFT>{"reply":"请告诉我更多需求细节","ready":false}</REQUIREMENT_DRAFT>`;
+    const result = extractRequirementDraft(answer);
+    expect(result).not.toBeNull();
+    expect(result!.reply).toBe("请告诉我更多需求细节");
+    expect(result!.ready).toBe(false);
+    expect(result!.draft).toBeUndefined();
+  });
+});
+
+describe("containsRequirementMarker", () => {
+  it("returns true when marker present", () => {
+    expect(containsRequirementMarker("text <REQUIREMENT_DRAFT>...")).toBe(true);
+  });
+
+  it("returns false when marker absent", () => {
+    expect(containsRequirementMarker("普通文本")).toBe(false);
+  });
+});
+
+describe("requirement service (DB)", () => {
+  let workspaceId: number;
+  let userId: number;
+  let userId2: number;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    getDb();
+    const ws = createWorkspace({ name: "SvcWS", slug: `svc-ws-${Date.now()}` });
+    workspaceId = ws.id;
+    const user = upsertUser({ feishu_user_id: `svc-user-${Date.now()}`, name: "Creator" });
+    userId = user.id;
+    const user2 = upsertUser({ feishu_user_id: `svc-user2-${Date.now()}`, name: "Member" });
+    userId2 = user2.id;
+    addWorkspaceMember(workspaceId, userId);
+  });
+
+  afterEach(() => {
+    closeDb();
+    mock.restore();
+  });
+
+  it("createDraft creates a draft with defaults", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    expect(draft.id).toBeGreaterThan(0);
+    expect(draft.workspace_id).toBe(workspaceId);
+    expect(draft.creator_id).toBe(userId);
+    expect(draft.status).toBe("drafting");
+  });
+
+  it("createDraft stores feishuChatId", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId, feishuChatId: "chat-xyz" });
+    expect(draft.feishu_chat_id).toBe("chat-xyz");
+  });
+
+  it("getDraft returns draft for creator", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { draft: fetched, error } = getDraft(draft.id, userId);
+    expect(error).toBeUndefined();
+    expect(fetched).not.toBeNull();
+    expect(fetched!.id).toBe(draft.id);
+  });
+
+  it("getDraft returns draft for workspace member", () => {
+    addWorkspaceMember(workspaceId, userId2);
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { draft: fetched, error } = getDraft(draft.id, userId2);
+    expect(error).toBeUndefined();
+    expect(fetched).not.toBeNull();
+  });
+
+  it("getDraft returns error for non-member", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { draft: fetched, error } = getDraft(draft.id, userId2);
+    expect(fetched).toBeNull();
+    expect(error).toBeTruthy();
+  });
+
+  it("getDraft returns error for non-existent draft", () => {
+    const { draft, error } = getDraft(999999, userId);
+    expect(draft).toBeNull();
+    expect(error).toBeTruthy();
+  });
+
+  it("patchDraft succeeds for creator in drafting status", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { ok } = patchDraft({
+      draftId: draft.id,
+      userId,
+      patch: { issue_title: "新标题", prd_content: "内容" },
+    });
+    expect(ok).toBe(true);
+
+    const { draft: updated } = getDraft(draft.id, userId);
+    expect(updated!.issue_title).toBe("新标题");
+    expect(updated!.prd_content).toBe("内容");
+  });
+
+  it("patchDraft succeeds for workspace member", () => {
+    addWorkspaceMember(workspaceId, userId2);
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { ok } = patchDraft({
+      draftId: draft.id,
+      userId: userId2,
+      patch: { issue_title: "成员修改" },
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("patchDraft fails for non-member", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    const { ok, error } = patchDraft({
+      draftId: draft.id,
+      userId: userId2,
+      patch: { issue_title: "无权修改" },
+    });
+    expect(ok).toBe(false);
+    expect(error).toContain("无权限");
+  });
+
+  it("patchDraft fails when status is approved", () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    updateRequirementDraft(draft.id, { status: "approved" });
+
+    const { ok, error } = patchDraft({
+      draftId: draft.id,
+      userId,
+      patch: { issue_title: "修改已审批草稿" },
+    });
+    expect(ok).toBe(false);
+    expect(error).toContain("不允许编辑");
+  });
+
+  it("patchDraft fails for non-existent draft", () => {
+    const { ok, error } = patchDraft({
+      draftId: 999999,
+      userId,
+      patch: { issue_title: "不存在" },
+    });
+    expect(ok).toBe(false);
+    expect(error).toContain("不存在");
+  });
+
+  it("listDrafts filters by workspaceId", () => {
+    createDraft({ workspaceId, creatorId: userId });
+    createDraft({ workspaceId, creatorId: userId });
+    const drafts = listDrafts({ workspaceId });
+    expect(drafts.length).toBe(2);
+  });
+
+  it("listDrafts filters by userId", () => {
+    createDraft({ workspaceId, creatorId: userId });
+    const ws2 = createWorkspace({ name: "WS2", slug: `ws2-${Date.now()}` });
+    createDraft({ workspaceId: ws2.id, creatorId: userId2 });
+
+    const mine = listDrafts({ userId });
+    expect(mine.length).toBe(1);
+    expect(mine[0].creator_id).toBe(userId);
+  });
+
+  it("listDrafts filters by status", () => {
+    const d1 = createDraft({ workspaceId, creatorId: userId });
+    createDraft({ workspaceId, creatorId: userId });
+    updateRequirementDraft(d1.id, { status: "review" });
+
+    const reviewing = listDrafts({ workspaceId, status: "review" });
+    expect(reviewing.length).toBe(1);
+    expect(reviewing[0].id).toBe(d1.id);
+  });
+});

--- a/packages/gateway/src/services/requirement.ts
+++ b/packages/gateway/src/services/requirement.ts
@@ -1,0 +1,215 @@
+import { getConfig } from "../config";
+import {
+  createRequirementDraft,
+  getRequirementDraft,
+  listRequirementDrafts,
+  updateRequirementDraft,
+  getWorkspaceMemberRole,
+} from "../db/queries";
+import { streamRequirementChatflow } from "./dify";
+import type { RequirementDraft, RequirementDraftStatus } from "../types";
+
+// ─── Parser ────────────────────────────────────────────────────────────────────
+
+const REQUIREMENT_DRAFT_MARKER_START = "<REQUIREMENT_DRAFT>";
+const REQUIREMENT_DRAFT_MARKER_END = "</REQUIREMENT_DRAFT>";
+
+export interface RequirementDraftPayload {
+  reply: string;
+  ready: boolean;
+  draft?: {
+    issue_title: string;
+    issue_description: string;
+    prd_content: string;
+    prd_slug?: string;
+  };
+}
+
+export function extractRequirementDraft(answer: string): RequirementDraftPayload | null {
+  const startIdx = answer.indexOf(REQUIREMENT_DRAFT_MARKER_START);
+  const endIdx = answer.indexOf(REQUIREMENT_DRAFT_MARKER_END);
+
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
+
+  const jsonStr = answer.slice(startIdx + REQUIREMENT_DRAFT_MARKER_START.length, endIdx).trim();
+  try {
+    const parsed = JSON.parse(jsonStr) as RequirementDraftPayload;
+    return {
+      reply: parsed.reply ?? "",
+      ready: parsed.ready ?? false,
+      draft: parsed.draft,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function containsRequirementMarker(text: string): boolean {
+  return text.includes(REQUIREMENT_DRAFT_MARKER_START);
+}
+
+// ─── Service ───────────────────────────────────────────────────────────────────
+
+export function createDraft(params: {
+  workspaceId: number;
+  creatorId: number;
+  feishuChatId?: string;
+}): RequirementDraft {
+  return createRequirementDraft({
+    workspace_id: params.workspaceId,
+    creator_id: params.creatorId,
+    feishu_chat_id: params.feishuChatId,
+  });
+}
+
+export async function* chatDraft(params: {
+  draftId: number;
+  userId: number;
+  message: string;
+}): AsyncGenerator<{ event: string; data: string }> {
+  const draft = getRequirementDraft(params.draftId);
+  if (!draft) {
+    yield { event: "error", data: JSON.stringify({ message: "草稿不存在" }) };
+    return;
+  }
+
+  const config = getConfig();
+  if (!config.difyRequirementChatApiKey) {
+    yield { event: "error", data: JSON.stringify({ message: "requirement chat not configured" }) };
+    return;
+  }
+
+  let fullAnswer = "";
+  let convId = draft.dify_conversation_id ?? "";
+  let markerDetected = false;
+
+  try {
+    for await (const chunk of streamRequirementChatflow({
+      query: params.message,
+      conversationId: draft.dify_conversation_id ?? undefined,
+      userId: String(params.userId),
+      workspaceId: draft.workspace_id,
+      apiKey: config.difyRequirementChatApiKey,
+      baseUrl: config.difyBaseUrl,
+    })) {
+      if (chunk.event === "message" && chunk.answer) {
+        convId = convId || chunk.conversation_id || "";
+        fullAnswer += chunk.answer;
+
+        if (markerDetected) continue;
+
+        if (containsRequirementMarker(fullAnswer)) {
+          markerDetected = true;
+          continue;
+        }
+
+        yield {
+          event: "message",
+          data: JSON.stringify({
+            type: "text",
+            content: chunk.answer,
+            conversation_id: convId,
+          }),
+        };
+      }
+
+      if (chunk.event === "message_end") {
+        const parsed = extractRequirementDraft(fullAnswer);
+        const updatePatch: Parameters<typeof updateRequirementDraft>[1] = {};
+
+        if (convId) {
+          updatePatch.dify_conversation_id = convId;
+        }
+
+        if (parsed?.draft) {
+          updatePatch.issue_title = parsed.draft.issue_title;
+          updatePatch.issue_description = parsed.draft.issue_description;
+          updatePatch.prd_content = parsed.draft.prd_content;
+          if (parsed.draft.prd_slug) {
+            updatePatch.prd_slug = parsed.draft.prd_slug;
+          }
+        }
+
+        if (Object.keys(updatePatch).length > 0) {
+          updateRequirementDraft(params.draftId, updatePatch);
+        }
+
+        yield {
+          event: "message_end",
+          data: JSON.stringify({
+            conversation_id: convId,
+            ready: parsed?.ready ?? false,
+            draft: parsed?.draft ?? null,
+          }),
+        };
+      }
+    }
+  } catch (err) {
+    yield {
+      event: "error",
+      data: JSON.stringify({
+        message: `对话失败: ${err instanceof Error ? err.message : "未知错误"}`,
+      }),
+    };
+  }
+}
+
+export function patchDraft(params: {
+  draftId: number;
+  userId: number;
+  patch: {
+    issue_title?: string;
+    issue_description?: string;
+    prd_content?: string;
+  };
+}): { ok: boolean; error?: string } {
+  const draft = getRequirementDraft(params.draftId);
+  if (!draft) {
+    return { ok: false, error: "草稿不存在" };
+  }
+
+  if (draft.status !== "drafting" && draft.status !== "review") {
+    return { ok: false, error: "当前状态不允许编辑" };
+  }
+
+  const memberRole = getWorkspaceMemberRole(draft.workspace_id, params.userId);
+  const isCreator = draft.creator_id === params.userId;
+
+  if (!isCreator && !memberRole) {
+    return { ok: false, error: "无权限编辑此草稿" };
+  }
+
+  updateRequirementDraft(params.draftId, params.patch);
+  return { ok: true };
+}
+
+export function getDraft(
+  draftId: number,
+  userId: number,
+): { draft: RequirementDraft | null; error?: string } {
+  const draft = getRequirementDraft(draftId);
+  if (!draft) return { draft: null, error: "草稿不存在" };
+
+  const memberRole = getWorkspaceMemberRole(draft.workspace_id, userId);
+  const isCreator = draft.creator_id === userId;
+
+  if (!isCreator && !memberRole) {
+    return { draft: null, error: "无权限访问此草稿" };
+  }
+
+  return { draft };
+}
+
+export function listDrafts(params: {
+  workspaceId?: number;
+  userId?: number;
+  status?: RequirementDraftStatus;
+  limit?: number;
+}): RequirementDraft[] {
+  return listRequirementDrafts({
+    workspace_id: params.workspaceId,
+    creator_id: params.userId,
+    status: params.status,
+    limit: params.limit,
+  });
+}

--- a/packages/gateway/src/types/index.ts
+++ b/packages/gateway/src/types/index.ts
@@ -165,3 +165,25 @@ export interface WorkspaceMember {
   role: "admin" | "member";
   created_at: string;
 }
+
+// 需求草稿
+export type RequirementDraftStatus = "drafting" | "review" | "approved" | "rejected" | "abandoned";
+
+export interface RequirementDraft {
+  id: number;
+  workspace_id: number;
+  creator_id: number;
+  status: RequirementDraftStatus;
+  issue_title: string;
+  issue_description: string;
+  prd_content: string;
+  prd_slug: string | null;
+  dify_conversation_id: string | null;
+  plane_issue_id: string | null;
+  prd_git_path: string | null;
+  feishu_chat_id: string | null;
+  feishu_card_id: string | null;
+  created_at: string;
+  updated_at: string;
+  approved_at: string | null;
+}


### PR DESCRIPTION
P1 of #78 — 需求对话化重设计的 Gateway 后端基础能力。

## Summary
- 新增 requirement_drafts 表 + CRUD queries (+14 测试)
- requirement service: createDraft / chatDraft(SSE) / patchDraft / getDraft / listDrafts (+22 测试)
- Dify streamRequirementChatflow + <REQUIREMENT_DRAFT> marker parser
- 5 个新路由 /api/requirement/* (draft/get/list/patch/chat)
- 新配置项 DIFY_REQUIREMENT_CHAT_API_KEY
- 附带：重设计 spec + E2E 验证 plan 文档
- 修复 git.test.ts mock fs 无限递归

## Scope
只做后端。P2(Web)/P3(飞书)/P4(approve) 后续 PR。/api/prd/chat 保留兼容。

## Test
- bun test: 297 pass (+36), 0 fail
- bun run lint: 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)