### PR TITLE
feat(web): 需求对话页 + 列表 (P2 of #78)

### DIFF
--- a/packages/web/src/api/requirement.ts
+++ b/packages/web/src/api/requirement.ts
@@ -1,0 +1,153 @@
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
+export type RequirementDraftStatus = "drafting" | "review" | "approved" | "rejected" | "abandoned";
+
+export interface RequirementDraft {
+  id: number;
+  workspace_id: number;
+  creator_id: number;
+  status: RequirementDraftStatus;
+  issue_title: string;
+  issue_description: string;
+  prd_content: string;
+  prd_slug: string | null;
+  dify_conversation_id: string | null;
+  plane_issue_id: string | null;
+  prd_git_path: string | null;
+  feishu_chat_id: string | null;
+  feishu_card_id: string | null;
+  created_at: string;
+  updated_at: string;
+  approved_at: string | null;
+}
+
+export interface RequirementDraftListResponse {
+  data: RequirementDraft[];
+  total: number;
+}
+
+function getHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  const token = localStorage.getItem("arcflow_token");
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  const wsId = localStorage.getItem("arcflow_workspace_id");
+  if (wsId) headers["X-Workspace-Id"] = wsId;
+  return headers;
+}
+
+async function request<T>(url: string, options?: RequestInit): Promise<T> {
+  const res = await fetch(`${API_BASE}${url}`, {
+    ...options,
+    headers: { ...getHeaders(), ...(options?.headers as Record<string, string>) },
+  });
+  if (res.status === 401) {
+    localStorage.removeItem("arcflow_token");
+    window.location.href = "/login";
+    throw new Error("Unauthorized");
+  }
+  if (!res.ok) throw new Error(`请求失败: ${res.status}`);
+  return res.json() as Promise<T>;
+}
+
+export function createRequirementDraft(params: {
+  workspace_id: number;
+  feishu_chat_id?: string;
+}): Promise<RequirementDraft> {
+  return request<RequirementDraft>("/api/requirement/draft", {
+    method: "POST",
+    body: JSON.stringify(params),
+  });
+}
+
+export function getRequirementDraft(id: number): Promise<RequirementDraft> {
+  return request<RequirementDraft>(`/api/requirement/draft/${id}`);
+}
+
+export function listRequirementDrafts(params: {
+  workspace_id?: number;
+  status?: string;
+  limit?: number;
+}): Promise<RequirementDraftListResponse> {
+  const q = new URLSearchParams();
+  if (params.workspace_id) q.set("workspace_id", String(params.workspace_id));
+  if (params.status) q.set("status", params.status);
+  if (params.limit) q.set("limit", String(params.limit));
+  return request<RequirementDraftListResponse>(`/api/requirement/drafts?${q}`);
+}
+
+export function patchRequirementDraft(
+  id: number,
+  patch: Partial<{
+    issue_title: string;
+    issue_description: string;
+    prd_content: string;
+    status: RequirementDraftStatus;
+  }>,
+): Promise<RequirementDraft> {
+  return request<RequirementDraft>(`/api/requirement/draft/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(patch),
+  });
+}
+
+export type SSEChatEvent =
+  | { type: "text"; content: string }
+  | {
+      type: "draft_update";
+      issue_title?: string;
+      issue_description?: string;
+      prd_content?: string;
+      prd_slug?: string;
+    }
+  | { type: "done" }
+  | { type: "error"; message: string };
+
+export function streamRequirementChat(
+  id: number,
+  message: string,
+  onEvent: (event: SSEChatEvent) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  const token = localStorage.getItem("arcflow_token");
+  const wsId = localStorage.getItem("arcflow_workspace_id");
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (wsId) headers["X-Workspace-Id"] = wsId;
+
+  return fetch(`${API_BASE}/api/requirement/draft/${id}/chat`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ message }),
+    signal,
+  }).then((res) => {
+    if (!res.ok) throw new Error(`请求失败: ${res.status}`);
+    if (!res.body) throw new Error("No response body");
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    function pump(): Promise<void> {
+      return reader.read().then(({ done, value }) => {
+        if (done) return;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+        for (const line of lines) {
+          if (!line.startsWith("data:")) continue;
+          const raw = line.slice(5).trim();
+          if (!raw) continue;
+          try {
+            const parsed = JSON.parse(raw) as SSEChatEvent;
+            onEvent(parsed);
+          } catch {
+            // skip malformed
+          }
+        }
+        return pump();
+      });
+    }
+
+    return pump();
+  });
+}

--- a/packages/web/src/components/AppLayout.vue
+++ b/packages/web/src/components/AppLayout.vue
@@ -270,6 +270,7 @@ import {
   CalendarDays,
   Package,
   BarChart3,
+  ClipboardList,
 } from "lucide-vue-next";
 import { useThemeStore } from "../stores/theme";
 import UiDialog from "./ui/AppDialog.vue";
@@ -288,6 +289,7 @@ const wsNameInput = ref<HTMLInputElement | null>(null);
 const navItems = computed(() => {
   const items = [
     { path: "/dashboard", label: "仪表盘", icon: LayoutDashboard },
+    { path: "/requirements", label: "需求", icon: ClipboardList },
     { path: "/chat", label: "AI 对话", icon: MessageSquare },
     { path: "/docs", label: "文档", icon: FileText },
     { path: "/workflows", label: "工作流", icon: List },
@@ -318,7 +320,10 @@ const currentPageTitle = computed(() => {
 });
 
 const isFullWidthPage = computed(
-  () => route.path.startsWith("/docs") || route.path.startsWith("/chat"),
+  () =>
+    route.path.startsWith("/docs") ||
+    route.path.startsWith("/chat") ||
+    route.path.startsWith("/requirements/"),
 );
 
 function isActive(path: string) {

--- a/packages/web/src/pages/RequirementChat.vue
+++ b/packages/web/src/pages/RequirementChat.vue
@@ -1,0 +1,540 @@
+<!-- eslint-disable vue/no-v-html -->
+<template>
+  <div class="flex" style="height: calc(100vh - 48px)">
+    <!-- 左：对话区 -->
+    <div
+      class="flex flex-col min-w-0"
+      style="flex: 1; border-right: 1px solid var(--color-border-subtle)"
+    >
+      <!-- 顶栏 -->
+      <div
+        class="px-4 py-2 flex items-center justify-between shrink-0"
+        style="border-bottom: 1px solid var(--color-border-subtle)"
+      >
+        <div class="flex items-center gap-2">
+          <button
+            class="flex items-center gap-1.5 text-xs cursor-pointer"
+            style="background: none; border: none; color: var(--color-text-quaternary)"
+            @click="$router.push('/requirements')"
+          >
+            <ChevronLeft :size="14" />
+            需求列表
+          </button>
+          <span style="color: var(--color-border-default)">·</span>
+          <span class="text-xs" style="color: var(--color-text-tertiary); font-weight: 510">
+            {{ store.currentDraft?.issue_title || "新需求草稿" }}
+          </span>
+        </div>
+        <div class="flex items-center gap-2">
+          <span
+            class="text-xs px-2 py-0.5 rounded-full"
+            :style="statusStyle(store.currentDraft?.status)"
+          >
+            {{ statusLabel(store.currentDraft?.status) }}
+          </span>
+          <button
+            class="px-3 py-1.5 rounded-md text-xs font-medium cursor-pointer"
+            :disabled="!canFinalize"
+            :style="{
+              backgroundColor: canFinalize ? 'var(--color-accent)' : 'var(--color-surface-05)',
+              color: canFinalize ? '#fff' : 'var(--color-text-quaternary)',
+              border: 'none',
+              cursor: canFinalize ? 'pointer' : 'not-allowed',
+            }"
+            @click="handleFinalize"
+          >
+            {{ store.currentDraft?.status === "review" ? "已提交 Review" : "完成草稿" }}
+          </button>
+        </div>
+      </div>
+
+      <!-- 消息列表 -->
+      <div ref="msgContainer" class="flex-1 overflow-y-auto px-6 py-4">
+        <!-- 空态提示 -->
+        <div v-if="messages.length === 0" class="flex flex-col items-center justify-center h-full">
+          <MessageSquare
+            :size="40"
+            style="color: var(--color-border-default); margin-bottom: 12px"
+          />
+          <p class="text-sm" style="color: var(--color-text-quaternary)">
+            开始描述你的需求，AI 将帮你生成 PRD 草稿
+          </p>
+        </div>
+
+        <div v-for="(msg, idx) in messages" :key="idx" class="mb-4">
+          <div v-if="msg.role === 'user'" class="flex justify-end">
+            <div
+              class="max-w-lg px-3 py-2 rounded-lg text-sm"
+              style="background-color: rgba(94, 106, 210, 0.15); color: var(--color-text-primary)"
+            >
+              {{ msg.content }}
+            </div>
+          </div>
+          <div v-else class="flex gap-2">
+            <div
+              class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center text-xs mt-0.5"
+              style="background-color: var(--color-surface-05); color: var(--color-text-tertiary)"
+            >
+              AI
+            </div>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div
+              class="prose text-sm max-w-2xl flex-1"
+              v-html="
+                msg.content ? renderMd(msg.content) : '<span class=\'streaming-cursor\'>···</span>'
+              "
+            />
+          </div>
+        </div>
+
+        <div
+          v-if="store.streaming && messages[messages.length - 1]?.role === 'user'"
+          class="flex gap-2 mb-4"
+        >
+          <div
+            class="w-6 h-6 rounded-full shrink-0 flex items-center justify-center text-xs"
+            style="background-color: var(--color-surface-05); color: var(--color-text-tertiary)"
+          >
+            AI
+          </div>
+          <span class="text-sm animate-pulse" style="color: var(--color-text-tertiary)">···</span>
+        </div>
+      </div>
+
+      <!-- 输入框 -->
+      <div class="px-6 pb-4 pt-2 shrink-0">
+        <div
+          v-if="store.error"
+          class="mb-2 px-3 py-1.5 rounded-md text-xs"
+          style="
+            background-color: rgba(239, 68, 68, 0.08);
+            border: 1px solid rgba(239, 68, 68, 0.2);
+            color: var(--color-error-light);
+          "
+        >
+          {{ store.error }}
+        </div>
+        <div
+          class="flex items-end gap-2 p-3 rounded-lg"
+          style="
+            background-color: var(--color-surface-02);
+            border: 1px solid var(--color-border-default);
+          "
+        >
+          <textarea
+            v-model="inputText"
+            rows="1"
+            placeholder="描述你的需求，Shift+Enter 换行，Enter 发送"
+            class="flex-1 bg-transparent outline-none resize-none text-sm"
+            style="color: var(--color-text-secondary); max-height: 144px"
+            :disabled="store.streaming || isReadonly"
+            @keydown.enter.exact.prevent="handleSend"
+          />
+          <button
+            class="w-8 h-8 rounded-full flex items-center justify-center shrink-0 text-white cursor-pointer"
+            style="background-color: var(--color-accent); border: none"
+            :disabled="store.streaming || isReadonly"
+            @click="handleSend"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+            >
+              <path d="M22 2L11 13M22 2l-7 20-4-9-9-4 20-7z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- 右：草稿预览 -->
+    <div class="flex flex-col min-w-0" style="flex: 1">
+      <!-- Tab 栏 -->
+      <div
+        class="flex items-center gap-0 px-4 shrink-0"
+        style="border-bottom: 1px solid var(--color-border-subtle)"
+      >
+        <button
+          v-for="tab in tabs"
+          :key="tab.key"
+          class="px-4 py-2.5 text-xs font-medium cursor-pointer"
+          style="
+            background: none;
+            border: none;
+            border-bottom: 2px solid transparent;
+            transition: all 120ms ease;
+          "
+          :style="{
+            color:
+              activeTab === tab.key ? 'var(--color-text-primary)' : 'var(--color-text-quaternary)',
+            borderBottomColor: activeTab === tab.key ? 'var(--color-accent)' : 'transparent',
+          }"
+          @click="activeTab = tab.key"
+        >
+          {{ tab.label }}
+        </button>
+      </div>
+
+      <!-- 内容区 -->
+      <div class="flex-1 overflow-y-auto">
+        <!-- PRD Tab -->
+        <div v-if="activeTab === 'prd'" class="h-full">
+          <div
+            v-if="!store.currentDraft?.prd_content"
+            class="flex flex-col items-center justify-center h-full"
+          >
+            <FileText :size="40" style="color: var(--color-border-default); margin-bottom: 12px" />
+            <p class="text-sm text-center px-8" style="color: var(--color-text-quaternary)">
+              AI 正在生成中，先在左侧对话吧
+            </p>
+          </div>
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div
+            v-else
+            class="prose px-8 py-6 max-w-none text-sm"
+            v-html="renderMd(store.currentDraft.prd_content)"
+          />
+        </div>
+
+        <!-- Issue 预览 Tab -->
+        <div v-else-if="activeTab === 'issue'" class="px-8 py-6">
+          <div
+            v-if="!store.currentDraft?.issue_title"
+            class="flex flex-col items-center justify-center h-32"
+          >
+            <p class="text-sm" style="color: var(--color-text-quaternary)">暂无 Issue 信息</p>
+          </div>
+          <template v-else>
+            <h2 class="text-base mb-4" style="font-weight: 590; color: var(--color-text-primary)">
+              {{ store.currentDraft.issue_title }}
+            </h2>
+            <!-- eslint-disable-next-line vue/no-v-html -->
+            <div
+              v-if="store.currentDraft.issue_description"
+              class="prose text-sm max-w-none"
+              v-html="renderMd(store.currentDraft.issue_description)"
+            />
+            <p v-else class="text-sm" style="color: var(--color-text-quaternary)">暂无描述</p>
+          </template>
+        </div>
+
+        <!-- 编辑 Tab -->
+        <div v-else-if="activeTab === 'edit'" class="px-6 py-4 flex flex-col gap-4">
+          <div>
+            <label
+              class="block text-xs mb-1.5"
+              style="color: var(--color-text-quaternary); font-weight: 510"
+            >
+              Issue 标题
+            </label>
+            <input
+              v-model="editTitle"
+              class="w-full px-3 py-2 rounded-md text-sm outline-none"
+              style="
+                background-color: var(--color-surface-02);
+                border: 1px solid var(--color-border-default);
+                color: var(--color-text-primary);
+              "
+              placeholder="Issue 标题"
+              :disabled="isReadonly"
+            />
+          </div>
+          <div>
+            <label
+              class="block text-xs mb-1.5"
+              style="color: var(--color-text-quaternary); font-weight: 510"
+            >
+              Issue 描述（Markdown）
+            </label>
+            <textarea
+              v-model="editIssueDesc"
+              rows="6"
+              class="w-full px-3 py-2 rounded-md text-sm outline-none resize-none"
+              style="
+                background-color: var(--color-surface-02);
+                border: 1px solid var(--color-border-default);
+                color: var(--color-text-primary);
+              "
+              placeholder="Issue 描述"
+              :disabled="isReadonly"
+            />
+          </div>
+          <div>
+            <label
+              class="block text-xs mb-1.5"
+              style="color: var(--color-text-quaternary); font-weight: 510"
+            >
+              PRD 正文（Markdown）
+            </label>
+            <textarea
+              v-model="editPrdContent"
+              rows="14"
+              class="w-full px-3 py-2 rounded-md text-sm outline-none resize-none font-mono"
+              style="
+                background-color: var(--color-surface-02);
+                border: 1px solid var(--color-border-default);
+                color: var(--color-text-primary);
+              "
+              placeholder="PRD 正文内容"
+              :disabled="isReadonly"
+            />
+          </div>
+          <div class="flex justify-end gap-2">
+            <button
+              class="px-4 py-1.5 rounded-md text-xs cursor-pointer"
+              style="
+                background: none;
+                border: 1px solid var(--color-border-default);
+                color: var(--color-text-secondary);
+              "
+              :disabled="store.loading"
+              @click="resetEditFields"
+            >
+              重置
+            </button>
+            <button
+              class="px-4 py-1.5 rounded-md text-xs text-white cursor-pointer"
+              style="background-color: var(--color-accent); border: none; font-weight: 510"
+              :disabled="store.loading || isReadonly"
+              @click="handleSaveEdit"
+            >
+              {{ store.loading ? "保存中..." : "保存" }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Toast -->
+    <Transition name="toast">
+      <div
+        v-if="toast"
+        class="fixed bottom-6 left-1/2 -translate-x-1/2 px-4 py-2 rounded-lg text-sm text-white z-50"
+        style="background-color: var(--color-accent); box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3)"
+      >
+        {{ toast }}
+      </div>
+    </Transition>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch, nextTick } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useRequirementStore } from "../stores/requirement";
+import { useWorkspaceStore } from "../stores/workspace";
+import { marked } from "marked";
+import { ChevronLeft, MessageSquare, FileText } from "lucide-vue-next";
+
+defineOptions({ name: "RequirementChatPage" });
+
+const route = useRoute();
+const router = useRouter();
+const store = useRequirementStore();
+const wsStore = useWorkspaceStore();
+
+const inputText = ref("");
+const activeTab = ref<"prd" | "issue" | "edit">("prd");
+const msgContainer = ref<HTMLElement | null>(null);
+const toast = ref("");
+let toastTimer: ReturnType<typeof setTimeout> | null = null;
+
+const tabs = [
+  { key: "prd" as const, label: "PRD 预览" },
+  { key: "issue" as const, label: "Issue 预览" },
+  { key: "edit" as const, label: "编辑" },
+];
+
+// Edit fields
+const editTitle = ref("");
+const editIssueDesc = ref("");
+const editPrdContent = ref("");
+
+const messages = computed(() => store.messages);
+
+const isReadonly = computed(() => {
+  const s = store.currentDraft?.status;
+  return s === "approved" || s === "rejected" || s === "abandoned";
+});
+
+const canFinalize = computed(() => store.currentDraft?.status === "drafting");
+
+function renderMd(content: string) {
+  if (!content) return "";
+  return marked.parse(content, { async: false }) as string;
+}
+
+function statusLabel(status?: string) {
+  const map: Record<string, string> = {
+    drafting: "草稿中",
+    review: "待 Review",
+    approved: "已通过",
+    rejected: "已拒绝",
+    abandoned: "已放弃",
+  };
+  return map[status ?? ""] ?? status ?? "-";
+}
+
+function statusStyle(status?: string) {
+  const base = "font-weight: 510;";
+  if (status === "drafting")
+    return `${base} background-color: rgba(94,106,210,0.12); color: var(--color-accent)`;
+  if (status === "review") return `${base} background-color: rgba(234,179,8,0.12); color: #ca8a04`;
+  if (status === "approved")
+    return `${base} background-color: rgba(34,197,94,0.12); color: var(--color-success)`;
+  if (status === "rejected")
+    return `${base} background-color: rgba(239,68,68,0.08); color: var(--color-error)`;
+  return `${base} background-color: var(--color-surface-05); color: var(--color-text-quaternary)`;
+}
+
+function showToast(msg: string) {
+  toast.value = msg;
+  if (toastTimer) clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast.value = "";
+  }, 2500);
+}
+
+function scrollToBottom() {
+  nextTick(() => {
+    if (msgContainer.value) {
+      msgContainer.value.scrollTop = msgContainer.value.scrollHeight;
+    }
+  });
+}
+
+function syncEditFields() {
+  editTitle.value = store.currentDraft?.issue_title ?? "";
+  editIssueDesc.value = store.currentDraft?.issue_description ?? "";
+  editPrdContent.value = store.currentDraft?.prd_content ?? "";
+}
+
+function resetEditFields() {
+  syncEditFields();
+}
+
+async function handleSend() {
+  if (!inputText.value.trim() || store.streaming) return;
+  const msg = inputText.value;
+  inputText.value = "";
+  await store.sendMessage(msg);
+  scrollToBottom();
+}
+
+async function handleSaveEdit() {
+  await store.saveEdit({
+    issue_title: editTitle.value,
+    issue_description: editIssueDesc.value,
+    prd_content: editPrdContent.value,
+  });
+  if (!store.error) {
+    showToast("保存成功");
+    activeTab.value = "prd";
+  }
+}
+
+async function handleFinalize() {
+  if (!canFinalize.value) return;
+  const ok = await store.finalize();
+  if (ok) {
+    showToast("草稿已提交 Review");
+  }
+}
+
+watch(() => store.messages.length, scrollToBottom);
+
+watch(
+  () => store.currentDraft,
+  () => syncEditFields(),
+  { deep: true },
+);
+
+watch(activeTab, (tab) => {
+  if (tab === "edit") syncEditFields();
+});
+
+onMounted(async () => {
+  const id = route.params.id;
+  if (id) {
+    await store.loadDraft(Number(id));
+  } else {
+    // /requirements/new — create draft then redirect
+    const wsId = wsStore.currentId;
+    if (!wsId) {
+      store.error = "请先选择工作空间";
+      return;
+    }
+    const draft = await store.createDraft(wsId);
+    if (draft) {
+      await router.replace({ name: "requirement-detail", params: { id: draft.id } });
+    }
+  }
+});
+</script>
+
+<style scoped>
+.prose :deep(h1),
+.prose :deep(h2),
+.prose :deep(h3) {
+  color: var(--color-text-primary);
+  font-weight: 590;
+  margin-top: 1.25em;
+  margin-bottom: 0.5em;
+}
+.prose :deep(p) {
+  color: var(--color-text-secondary);
+  line-height: 1.7;
+  margin-bottom: 0.75em;
+}
+.prose :deep(ul),
+.prose :deep(ol) {
+  color: var(--color-text-secondary);
+  padding-left: 1.5em;
+  margin-bottom: 0.75em;
+}
+.prose :deep(code) {
+  background-color: var(--color-surface-04);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.85em;
+}
+.prose :deep(pre) {
+  background-color: var(--color-surface-04);
+  padding: 12px;
+  border-radius: 6px;
+  overflow-x: auto;
+  margin-bottom: 0.75em;
+}
+.prose :deep(blockquote) {
+  border-left: 3px solid var(--color-border-default);
+  padding-left: 1em;
+  color: var(--color-text-tertiary);
+  margin: 0.75em 0;
+}
+.streaming-cursor {
+  color: var(--color-text-quaternary);
+  animation: pulse 1.2s infinite;
+}
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.3;
+  }
+}
+.toast-enter-active,
+.toast-leave-active {
+  transition: all 200ms ease;
+}
+.toast-enter-from,
+.toast-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(8px);
+}
+</style>

--- a/packages/web/src/pages/RequirementList.vue
+++ b/packages/web/src/pages/RequirementList.vue
@@ -1,0 +1,226 @@
+<template>
+  <div>
+    <!-- 顶部操作栏 -->
+    <div class="flex items-center justify-between mb-6">
+      <h1
+        class="text-2xl"
+        style="font-weight: 510; color: var(--color-text-primary); letter-spacing: -0.288px"
+      >
+        需求草稿
+      </h1>
+      <button
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm text-white cursor-pointer"
+        style="background-color: var(--color-accent); border: none; font-weight: 510"
+        @click="$router.push('/requirements/new')"
+      >
+        <Plus :size="14" />
+        新建需求
+      </button>
+    </div>
+
+    <!-- 状态过滤 -->
+    <div class="flex flex-wrap gap-2 mb-5">
+      <span
+        class="text-xs uppercase mr-2 self-center"
+        style="font-weight: 510; color: var(--color-text-quaternary); letter-spacing: 0.05em"
+      >
+        状态
+      </span>
+      <button
+        v-for="s in statusOptions"
+        :key="s.value"
+        class="filter-pill"
+        :class="{ active: filterStatus === s.value }"
+        @click="setFilter(s.value)"
+      >
+        {{ s.label }}
+      </button>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-if="store.error"
+      class="mb-4 p-3 rounded-md text-sm"
+      style="
+        background-color: rgba(239, 68, 68, 0.08);
+        border: 1px solid rgba(239, 68, 68, 0.2);
+        color: var(--color-error-light);
+      "
+    >
+      {{ store.error }}
+    </div>
+
+    <!-- Loading -->
+    <div
+      v-if="store.loading"
+      class="text-center py-10 text-sm"
+      style="color: var(--color-text-quaternary)"
+    >
+      加载中...
+    </div>
+
+    <!-- Table -->
+    <div v-else>
+      <div class="rounded-lg overflow-hidden" style="border: 1px solid var(--color-border-default)">
+        <table class="w-full">
+          <thead>
+            <tr style="border-bottom: 1px solid var(--color-border-subtle)">
+              <th class="table-header">标题</th>
+              <th class="table-header">状态</th>
+              <th class="table-header">更新时间</th>
+              <th class="table-header">创建时间</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="draft in store.drafts.data"
+              :key="draft.id"
+              class="table-row cursor-pointer"
+              @click="$router.push(`/requirements/${draft.id}`)"
+            >
+              <td class="table-cell">
+                <span style="color: var(--color-text-primary); font-weight: 510">
+                  {{ draft.issue_title || `草稿 #${draft.id}` }}
+                </span>
+              </td>
+              <td class="table-cell">
+                <span
+                  class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full"
+                  :style="statusBadgeStyle(draft.status)"
+                >
+                  {{ statusLabel(draft.status) }}
+                </span>
+              </td>
+              <td class="table-cell" style="color: var(--color-text-quaternary)">
+                {{ formatDate(draft.updated_at) }}
+              </td>
+              <td class="table-cell" style="color: var(--color-text-quaternary)">
+                {{ formatDate(draft.created_at) }}
+              </td>
+            </tr>
+            <tr v-if="store.drafts.data.length === 0">
+              <td
+                colspan="4"
+                class="table-cell text-center py-10"
+                style="color: var(--color-text-quaternary)"
+              >
+                暂无需求草稿，点击「新建需求」开始
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="mt-3 text-xs" style="color: var(--color-text-quaternary)">
+        共 {{ store.drafts.total }} 条记录
+      </p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { onMounted, ref } from "vue";
+import { useRequirementStore } from "../stores/requirement";
+import { Plus } from "lucide-vue-next";
+import type { RequirementDraftStatus } from "../api/requirement";
+
+defineOptions({ name: "RequirementListPage" });
+
+const store = useRequirementStore();
+const filterStatus = ref("");
+
+const statusOptions = [
+  { value: "", label: "全部" },
+  { value: "drafting", label: "草稿中" },
+  { value: "review", label: "待 Review" },
+  { value: "approved", label: "已通过" },
+  { value: "rejected", label: "已拒绝" },
+];
+
+function statusLabel(status: RequirementDraftStatus | string) {
+  const map: Record<string, string> = {
+    drafting: "草稿中",
+    review: "待 Review",
+    approved: "已通过",
+    rejected: "已拒绝",
+    abandoned: "已放弃",
+  };
+  return map[status] ?? status;
+}
+
+function statusBadgeStyle(status: string) {
+  if (status === "drafting")
+    return "background-color: rgba(94,106,210,0.12); color: var(--color-accent); font-weight: 510";
+  if (status === "review")
+    return "background-color: rgba(234,179,8,0.12); color: #ca8a04; font-weight: 510";
+  if (status === "approved")
+    return "background-color: rgba(34,197,94,0.12); color: var(--color-success); font-weight: 510";
+  if (status === "rejected")
+    return "background-color: rgba(239,68,68,0.08); color: var(--color-error); font-weight: 510";
+  return "background-color: var(--color-surface-05); color: var(--color-text-quaternary); font-weight: 510";
+}
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return "-";
+  const d = new Date(dateStr);
+  const now = new Date();
+  const diff = now.getTime() - d.getTime();
+  if (diff < 60000) return "刚刚";
+  if (diff < 3600000) return `${Math.floor(diff / 60000)} 分钟前`;
+  if (diff < 86400000) return `${Math.floor(diff / 3600000)} 小时前`;
+  return d.toLocaleDateString("zh-CN");
+}
+
+function setFilter(status: string) {
+  filterStatus.value = status;
+  store.loadDrafts({ status: status || undefined });
+}
+
+onMounted(() => {
+  store.loadDrafts();
+});
+</script>
+
+<style scoped>
+.filter-pill {
+  padding: 3px 10px;
+  font-size: 12px;
+  font-weight: 510;
+  border-radius: 9999px;
+  border: none;
+  cursor: pointer;
+  color: var(--color-text-tertiary);
+  background: transparent;
+  transition: all 120ms ease;
+}
+.filter-pill:hover {
+  color: var(--color-text-secondary);
+}
+.filter-pill.active {
+  background-color: var(--color-surface-08);
+  color: var(--color-text-primary);
+}
+.table-header {
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 12px;
+  font-weight: 510;
+  color: var(--color-text-quaternary);
+  text-transform: uppercase;
+}
+.table-row {
+  border-bottom: 1px solid var(--color-border-subtle);
+  transition: all 120ms ease;
+}
+.table-row:hover {
+  background-color: var(--color-surface-04);
+}
+.table-row:last-child {
+  border-bottom: none;
+}
+.table-cell {
+  padding: 10px 12px;
+  font-size: 13px;
+  font-weight: 400;
+  color: var(--color-text-secondary);
+}
+</style>

--- a/packages/web/src/router/index.ts
+++ b/packages/web/src/router/index.ts
@@ -49,6 +49,21 @@ const router = createRouter({
       redirect: "/chat",
     },
     {
+      path: "/requirements",
+      name: "requirements",
+      component: () => import("../pages/RequirementList.vue"),
+    },
+    {
+      path: "/requirements/new",
+      name: "requirements-new",
+      component: () => import("../pages/RequirementChat.vue"),
+    },
+    {
+      path: "/requirements/:id",
+      name: "requirement-detail",
+      component: () => import("../pages/RequirementChat.vue"),
+    },
+    {
       path: "/workspace/settings",
       name: "workspace-settings",
       component: () => import("../pages/WorkspaceSettings.vue"),

--- a/packages/web/src/stores/requirement.ts
+++ b/packages/web/src/stores/requirement.ts
@@ -1,0 +1,177 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import {
+  createRequirementDraft,
+  getRequirementDraft,
+  listRequirementDrafts,
+  patchRequirementDraft,
+  streamRequirementChat,
+  type RequirementDraft,
+  type RequirementDraftListResponse,
+} from "../api/requirement";
+
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
+export const useRequirementStore = defineStore("requirement", () => {
+  const currentDraft = ref<RequirementDraft | null>(null);
+  const drafts = ref<RequirementDraftListResponse>({ data: [], total: 0 });
+  const messages = ref<ChatMessage[]>([]);
+  const loading = ref(false);
+  const streaming = ref(false);
+  const error = ref<string | null>(null);
+
+  async function createDraft(workspaceId: number, feishuChatId?: string) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const draft = await createRequirementDraft({
+        workspace_id: workspaceId,
+        feishu_chat_id: feishuChatId,
+      });
+      currentDraft.value = draft;
+      messages.value = [];
+      return draft;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "创建失败";
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function loadDraft(id: number) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const draft = await getRequirementDraft(id);
+      currentDraft.value = draft;
+      messages.value = [];
+      return draft;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "加载失败";
+      return null;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function loadDrafts(params: { status?: string; limit?: number } = {}) {
+    loading.value = true;
+    error.value = null;
+    try {
+      const wsId = localStorage.getItem("arcflow_workspace_id");
+      const result = await listRequirementDrafts({
+        workspace_id: wsId ? Number(wsId) : undefined,
+        ...params,
+      });
+      drafts.value = result;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "加载失败";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function sendMessage(content: string) {
+    if (!currentDraft.value || streaming.value || !content.trim()) return;
+
+    error.value = null;
+
+    // Optimistic user message
+    messages.value.push({ role: "user", content });
+
+    // Placeholder assistant message
+    const aiMsg: ChatMessage = { role: "assistant", content: "" };
+    messages.value.push(aiMsg);
+
+    streaming.value = true;
+
+    try {
+      await streamRequirementChat(currentDraft.value.id, content, (event) => {
+        if (event.type === "text") {
+          aiMsg.content += event.content;
+        } else if (event.type === "draft_update") {
+          if (currentDraft.value) {
+            if (event.issue_title !== undefined) currentDraft.value.issue_title = event.issue_title;
+            if (event.issue_description !== undefined)
+              currentDraft.value.issue_description = event.issue_description;
+            if (event.prd_content !== undefined) currentDraft.value.prd_content = event.prd_content;
+            if (event.prd_slug !== undefined) currentDraft.value.prd_slug = event.prd_slug;
+          }
+        } else if (event.type === "error") {
+          error.value = event.message;
+        }
+      });
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "发送失败";
+      // Remove placeholder if empty
+      if (!aiMsg.content) {
+        const idx = messages.value.indexOf(aiMsg);
+        if (idx !== -1) messages.value.splice(idx, 1);
+      }
+    } finally {
+      streaming.value = false;
+    }
+  }
+
+  async function saveEdit(patch: {
+    issue_title?: string;
+    issue_description?: string;
+    prd_content?: string;
+  }) {
+    if (!currentDraft.value) return;
+    loading.value = true;
+    error.value = null;
+    try {
+      const updated = await patchRequirementDraft(currentDraft.value.id, patch);
+      currentDraft.value = updated;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "保存失败";
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  async function finalize() {
+    if (!currentDraft.value) return false;
+    loading.value = true;
+    error.value = null;
+    try {
+      const updated = await patchRequirementDraft(currentDraft.value.id, { status: "review" });
+      currentDraft.value = updated;
+      return true;
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : "提交失败";
+      return false;
+    } finally {
+      loading.value = false;
+    }
+  }
+
+  function reset() {
+    currentDraft.value = null;
+    messages.value = [];
+    error.value = null;
+    streaming.value = false;
+    loading.value = false;
+  }
+
+  return {
+    currentDraft,
+    drafts,
+    messages,
+    loading,
+    streaming,
+    error,
+    createDraft,
+    loadDraft,
+    loadDrafts,
+    sendMessage,
+    saveEdit,
+    finalize,
+    reset,
+  };
+});


### PR DESCRIPTION
P2 of #78 — Web 前端：PM 通过对话 AI 产出 PRD 草稿。

## Summary
- 新路由：`/requirements`、`/requirements/new`、`/requirements/:id`
- **RequirementChat.vue**：左侧 SSE 流式对话 + 右侧三 Tab（PRD 预览 / Issue 预览 / 编辑）+ 「完成草稿」按钮 + Toast
- **RequirementList.vue**：状态过滤 + 表格
- **api/requirement.ts + stores/requirement.ts**：5 接口封装 + Pinia
- AppLayout 侧边栏新增「需求」入口（ClipboardList 图标）

## Scope
只做 Web UI，复用 P1 已合并的 Gateway `/api/requirement/*` 接口。P3(飞书)/P4(approve) 后续。

## Test
- `bun run build` ✓ (341ms)
- `bun run lint` ✓ (0 error)
- dev server 路由加载 200

## 已知局限（P2 范围内）
- 对话历史不持久化（刷新丢失）
- 飞书通知 → P3
- approve 原子操作 → P4

🤖 Generated with [Claude Code](https://claude.com/claude-code)