### PR TITLE
feat: finalize + 飞书 PRD Review 卡片 (P3 of #78)

### DIFF
--- a/packages/gateway/src/routes/api.ts
+++ b/packages/gateway/src/routes/api.ts
@@ -17,7 +17,14 @@ import {
 } from "../services/prd";
 import { queryKnowledgeBase } from "../services/dify";
 import { syncGitToDify } from "../services/rag-sync";
-import { createDraft, chatDraft, patchDraft, getDraft, listDrafts } from "../services/requirement";
+import {
+  createDraft,
+  chatDraft,
+  patchDraft,
+  getDraft,
+  listDrafts,
+  finalizeDraft,
+} from "../services/requirement";
 import type {
   TriggerWorkflowRequest,
   WorkflowType,
@@ -328,4 +335,26 @@ apiRoutes.post("/requirement/:id/chat", async (c) => {
       await stream.writeSSE({ event, data });
     }
   });
+});
+
+apiRoutes.post("/requirement/:id/finalize", async (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) {
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  const id = Number(c.req.param("id"));
+  if (isNaN(id)) return c.json({ error: "Invalid ID" }, 400);
+
+  const result = await finalizeDraft({ draftId: id, userId });
+  if (!result.ok) {
+    const status = result.error?.includes("不存在")
+      ? 404
+      : result.error?.includes("无权限")
+        ? 403
+        : 400;
+    return c.json({ error: result.error }, status);
+  }
+
+  return c.json({ draft: result.draft, feishu_sent: result.feishu_sent });
 });

--- a/packages/gateway/src/routes/webhook.test.ts
+++ b/packages/gateway/src/routes/webhook.test.ts
@@ -417,3 +417,145 @@ describe("webhook routes", () => {
     );
   });
 });
+
+describe("feishu webhook - requirement callbacks", () => {
+  let app: Hono;
+
+  beforeEach(async () => {
+    process.env.NODE_ENV = "test";
+    configOverrides = {};
+    getDb();
+    app = new Hono();
+    app.route("/webhook", createWebhookRoutes());
+    spyOn(workflowService, "triggerWorkflow").mockResolvedValue(1);
+    spyOn(ibuildLogFetcher, "fetchBuildLogWithContext").mockResolvedValue("mocked build log");
+  });
+
+  afterEach(() => {
+    closeDb();
+    mock.restore();
+    configOverrides = {};
+  });
+
+  async function seedDraftInReview() {
+    const { createWorkspace, upsertUser, createRequirementDraft, updateRequirementDraft } =
+      await import("../db/queries");
+    const ws = createWorkspace({ name: "ReqWS", slug: `req-ws-${Date.now()}` });
+    const user = upsertUser({ feishu_user_id: `req-user-${Date.now()}`, name: "PM" });
+    const draft = createRequirementDraft({
+      workspace_id: ws.id,
+      creator_id: user.id,
+      feishu_chat_id: "chat-req-test",
+    });
+    updateRequirementDraft(draft.id, {
+      status: "review",
+      issue_title: "用户登录",
+      feishu_card_id: "msg-card-001",
+    });
+    return { draft, ws, user };
+  }
+
+  it("POST /webhook/feishu requirement_approve updates status to approved", async () => {
+    const feishuService = await import("../services/feishu");
+    spyOn(feishuService, "updateCard").mockResolvedValue();
+
+    const { draft } = await seedDraftInReview();
+
+    const actionValue = JSON.stringify({
+      type: "requirement_approve",
+      draft_id: draft.id,
+    });
+
+    const res = await app.request("/webhook/feishu", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: { value: actionValue } }),
+    });
+    expect(res.status).toBe(200);
+
+    const { getRequirementDraft } = await import("../db/queries");
+    const updated = getRequirementDraft(draft.id);
+    expect(updated?.status).toBe("approved");
+  });
+
+  it("POST /webhook/feishu requirement_reject updates status to rejected", async () => {
+    const feishuService = await import("../services/feishu");
+    spyOn(feishuService, "updateCard").mockResolvedValue();
+
+    const { draft } = await seedDraftInReview();
+
+    const actionValue = JSON.stringify({
+      type: "requirement_reject",
+      draft_id: draft.id,
+    });
+
+    const res = await app.request("/webhook/feishu", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: { value: actionValue } }),
+    });
+    expect(res.status).toBe(200);
+
+    const { getRequirementDraft } = await import("../db/queries");
+    const updated = getRequirementDraft(draft.id);
+    expect(updated?.status).toBe("rejected");
+  });
+
+  it("POST /webhook/feishu requirement_approve calls updateCard when feishu_card_id present", async () => {
+    const feishuService = await import("../services/feishu");
+    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
+
+    const { draft } = await seedDraftInReview();
+
+    const actionValue = JSON.stringify({
+      type: "requirement_approve",
+      draft_id: draft.id,
+    });
+
+    await app.request("/webhook/feishu", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: { value: actionValue } }),
+    });
+
+    await Bun.sleep(0); // flush promise queue for async updateCard
+
+    expect(updateCardSpy).toHaveBeenCalledWith(
+      "msg-card-001",
+      expect.objectContaining({
+        header: expect.objectContaining({
+          template: "green",
+        }),
+      }),
+    );
+  });
+
+  it("POST /webhook/feishu requirement_reject calls updateCard when feishu_card_id present", async () => {
+    const feishuService = await import("../services/feishu");
+    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
+
+    const { draft } = await seedDraftInReview();
+
+    const actionValue = JSON.stringify({
+      type: "requirement_reject",
+      draft_id: draft.id,
+    });
+
+    await app.request("/webhook/feishu", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ action: { value: actionValue } }),
+    });
+
+    await Bun.sleep(0);
+
+    expect(updateCardSpy).toHaveBeenCalledWith(
+      "msg-card-001",
+      expect.objectContaining({
+        header: expect.objectContaining({
+          template: "red",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/gateway/src/routes/webhook.ts
+++ b/packages/gateway/src/routes/webhook.ts
@@ -7,6 +7,8 @@ import {
   isEventProcessed,
   recordWebhookEvent,
   recordWebhookLog,
+  getRequirementDraft,
+  updateRequirementDraft,
   getWorkspaceByPlaneProject,
   getWorkspaceBySlug,
 } from "../db/queries";
@@ -15,6 +17,7 @@ import { fetchBuildLogWithContext } from "../services/ibuild-log-fetcher";
 import { shouldTriggerWorkflow, extractPrdPath } from "../services/plane-webhook";
 import type { PlaneWebhookPayload } from "../services/plane-webhook";
 import { syncRecentChanges } from "../services/rag-sync";
+import { updateCard } from "../services/feishu";
 
 export function createWebhookRoutes(): Hono {
   const config = getConfig();
@@ -125,9 +128,84 @@ export function createWebhookRoutes(): Hono {
     if (action?.value) {
       try {
         const value = JSON.parse(action.value);
-        const actionType = value.action; // "approve" or "reject"
+        const actionType = value.action; // "approve" or "reject" (tech review)
+        const callbackType = value.type; // "requirement_approve" or "requirement_reject"
         const issueId = value.issue_id;
 
+        // ── 需求 PRD Review 回调 ──────────────────────────────────────────
+        if (callbackType === "requirement_approve" || callbackType === "requirement_reject") {
+          const draftId = Number(value.draft_id);
+          if (draftId) {
+            const draft = getRequirementDraft(draftId);
+            if (draft && draft.status === "review") {
+              if (callbackType === "requirement_approve") {
+                // P3：仅变更状态为 approved，Stage D（Plane/Git 落地）留给 P4 实现
+                // TODO(P4): 触发 Stage D 原子操作（创建 Plane Issue + 写入 Git）
+                updateRequirementDraft(draftId, { status: "approved" });
+                console.log(
+                  `[feishu webhook] requirement draft ${draftId} approved (P4 Stage D pending)`,
+                );
+
+                if (draft.feishu_card_id) {
+                  const approvedCard = {
+                    config: { wide_screen_mode: true },
+                    header: {
+                      title: {
+                        tag: "plain_text",
+                        content: "✅ 需求 PRD 已通过，待落地（P4 实现）",
+                      },
+                      template: "green",
+                    },
+                    elements: [
+                      {
+                        tag: "div",
+                        text: {
+                          tag: "lark_md",
+                          content: `**标题：** ${draft.issue_title || "（无标题）"}\n\n已通过审批，正式落地（创建 Plane Issue + Git 归档）将在 P4 阶段实现。`,
+                        },
+                      },
+                    ],
+                  };
+                  updateCard(draft.feishu_card_id, approvedCard).catch((err) => {
+                    console.warn(
+                      `[feishu webhook] 更新卡片失败: ${err instanceof Error ? err.message : err}`,
+                    );
+                  });
+                }
+              } else {
+                // requirement_reject
+                updateRequirementDraft(draftId, { status: "rejected" });
+                console.log(`[feishu webhook] requirement draft ${draftId} rejected`);
+
+                if (draft.feishu_card_id) {
+                  const rejectedCard = {
+                    config: { wide_screen_mode: true },
+                    header: {
+                      title: { tag: "plain_text", content: "❌ 需求 PRD 已驳回" },
+                      template: "red",
+                    },
+                    elements: [
+                      {
+                        tag: "div",
+                        text: {
+                          tag: "lark_md",
+                          content: `**标题：** ${draft.issue_title || "（无标题）"}\n\n已驳回，请 PM 修改后重新提交。`,
+                        },
+                      },
+                    ],
+                  };
+                  updateCard(draft.feishu_card_id, rejectedCard).catch((err) => {
+                    console.warn(
+                      `[feishu webhook] 更新卡片失败: ${err instanceof Error ? err.message : err}`,
+                    );
+                  });
+                }
+              }
+            }
+          }
+        }
+
+        // ── 技术文档 Review 回调（原有逻辑） ────────────────────────────
         if (actionType === "approve" && issueId && value.workspace_id) {
           // Trigger code generation
           triggerWorkflow({

--- a/packages/gateway/src/services/feishu.test.ts
+++ b/packages/gateway/src/services/feishu.test.ts
@@ -9,8 +9,13 @@ mock.module("../config", () => ({
     }),
 }));
 
-const { sendNotification, sendBugNotification, sendTechReviewCard, updateCard } =
-  await import("./feishu");
+const {
+  sendNotification,
+  sendBugNotification,
+  sendTechReviewCard,
+  updateCard,
+  sendRequirementReviewCard,
+} = await import("./feishu");
 
 describe("feishu service", () => {
   const originalFetch = globalThis.fetch;
@@ -201,6 +206,109 @@ describe("feishu service", () => {
       const body = JSON.parse(patchCall!.init.body as string);
       expect(body.msg_type).toBe("interactive");
       expect(JSON.parse(body.content)).toEqual(updatedCard);
+    });
+  });
+
+  describe("sendRequirementReviewCard", () => {
+    it("should send card with correct title and three action buttons", async () => {
+      // Mock returns message_id in data field
+      mockFetchFn = mock(async (url: string, init: RequestInit) => {
+        fetchCalls.push({ url, init });
+        if (typeof url === "string" && url.includes("tenant_access_token")) {
+          return new Response(
+            JSON.stringify({ code: 0, tenant_access_token: "test-token-123", expire: 7200 }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        return new Response(JSON.stringify({ code: 0, data: { message_id: "msg-req-001" } }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      globalThis.fetch = mockFetchFn as unknown as typeof fetch;
+
+      const result = await sendRequirementReviewCard({
+        chatId: "chat-req-001",
+        draftId: 42,
+        title: "用户登录功能",
+        summary: "支持手机号验证码登录",
+        creatorName: "张三",
+        webBaseUrl: "http://localhost:5173",
+      });
+
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        expect(result.card_id).toBe("msg-req-001");
+      }
+
+      const msgCall = fetchCalls.find((c) => c.url.includes("/im/v1/messages"));
+      expect(msgCall).toBeDefined();
+
+      const body = JSON.parse(msgCall!.init.body as string);
+      expect(body.receive_id).toBe("chat-req-001");
+
+      const card = JSON.parse(body.content);
+      expect(card.header.title.content).toBe("📋 需求 PRD 草稿就绪");
+      expect(card.header.template).toBe("green");
+
+      // 验证三行信息
+      const divWithFields = card.elements.find(
+        (el: Record<string, unknown>) => el.tag === "div" && el.fields,
+      );
+      expect(divWithFields).toBeDefined();
+      const fieldTexts = (divWithFields.fields as Array<{ text: { content: string } }>).map(
+        (f) => f.text.content,
+      );
+      expect(fieldTexts.some((t) => t.includes("用户登录功能"))).toBe(true);
+      expect(fieldTexts.some((t) => t.includes("张三"))).toBe(true);
+
+      // 验证三个按钮
+      const actionEl = card.elements.find((el: Record<string, unknown>) => el.tag === "action");
+      expect(actionEl).toBeDefined();
+      expect(actionEl.actions.length).toBe(3);
+
+      const btnTexts = (actionEl.actions as Array<{ text: { content: string } }>).map(
+        (a) => a.text.content,
+      );
+      expect(btnTexts.some((t) => t.includes("查看详情"))).toBe(true);
+      expect(btnTexts.some((t) => t.includes("快速通过"))).toBe(true);
+      expect(btnTexts.some((t) => t.includes("驳回"))).toBe(true);
+
+      // 验证详情链接
+      const detailBtn = actionEl.actions.find((a: { text: { content: string }; url?: string }) =>
+        a.text.content.includes("查看详情"),
+      );
+      expect(detailBtn?.url).toBe("http://localhost:5173/requirements/42");
+    });
+
+    it("should return ok=false when feishu returns no message_id", async () => {
+      // 飞书成功但没有 message_id
+      mockFetchFn = mock(async (url: string, init: RequestInit) => {
+        fetchCalls.push({ url, init });
+        if (typeof url === "string" && url.includes("tenant_access_token")) {
+          return new Response(
+            JSON.stringify({ code: 0, tenant_access_token: "test-token-123", expire: 7200 }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+        // 无 message_id
+        return new Response(JSON.stringify({ code: 0, data: {} }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      globalThis.fetch = mockFetchFn as unknown as typeof fetch;
+
+      const result = await sendRequirementReviewCard({
+        chatId: "chat-req-002",
+        draftId: 99,
+        title: "测试",
+        summary: "测试摘要",
+        creatorName: "李四",
+        webBaseUrl: "http://localhost:5173",
+      });
+
+      expect(result.ok).toBe(false);
     });
   });
 });

--- a/packages/gateway/src/services/feishu.ts
+++ b/packages/gateway/src/services/feishu.ts
@@ -37,7 +37,11 @@ async function getAccessToken(): Promise<string> {
   return accessToken;
 }
 
-async function sendMessage(chatId: string, msgType: string, content: string): Promise<void> {
+async function sendMessage(
+  chatId: string,
+  msgType: string,
+  content: string,
+): Promise<{ message_id?: string }> {
   const token = await getAccessToken();
 
   const res = await fetch(
@@ -58,6 +62,14 @@ async function sendMessage(chatId: string, msgType: string, content: string): Pr
 
   if (!res.ok) {
     console.error(`Feishu send message failed: ${res.status}`);
+    return {};
+  }
+
+  try {
+    const json = (await res.json()) as { data?: { message_id?: string } };
+    return { message_id: json.data?.message_id };
+  } catch {
+    return {};
   }
 }
 
@@ -130,6 +142,87 @@ export async function sendTechReviewCard(params: TechReviewCardParams): Promise<
   };
 
   await sendMessage(params.chatId, "interactive", JSON.stringify(card));
+}
+
+export interface RequirementReviewCardParams {
+  chatId: string;
+  draftId: number;
+  title: string;
+  summary: string;
+  creatorName: string;
+  webBaseUrl: string;
+}
+
+export async function sendRequirementReviewCard(
+  params: RequirementReviewCardParams,
+): Promise<{ ok: true; card_id: string } | { ok: false; error: string }> {
+  const detailUrl = `${params.webBaseUrl}/requirements/${params.draftId}`;
+
+  const card = {
+    config: { wide_screen_mode: true },
+    header: {
+      title: { tag: "plain_text", content: "📋 需求 PRD 草稿就绪" },
+      template: "green",
+    },
+    elements: [
+      {
+        tag: "div",
+        fields: [
+          {
+            is_short: true,
+            text: { tag: "lark_md", content: `**标题：** ${params.title}` },
+          },
+          {
+            is_short: true,
+            text: { tag: "lark_md", content: `**创建者：** ${params.creatorName}` },
+          },
+        ],
+      },
+      {
+        tag: "div",
+        text: {
+          tag: "lark_md",
+          content: `**摘要：** ${params.summary}`,
+        },
+      },
+      {
+        tag: "action",
+        actions: [
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "📖 查看详情" },
+            type: "default",
+            url: detailUrl,
+          },
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "✅ 快速通过" },
+            type: "primary",
+            action_type: "request",
+            value: JSON.stringify({ type: "requirement_approve", draft_id: params.draftId }),
+          },
+          {
+            tag: "button",
+            text: { tag: "plain_text", content: "❌ 驳回" },
+            type: "danger",
+            action_type: "request",
+            value: JSON.stringify({ type: "requirement_reject", draft_id: params.draftId }),
+          },
+        ],
+      },
+    ],
+  };
+
+  try {
+    const result = await sendMessage(params.chatId, "interactive", JSON.stringify(card));
+    if (result.message_id) {
+      return { ok: true, card_id: result.message_id };
+    }
+    return { ok: false, error: "飞书未返回 message_id" };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "未知错误";
+    return { ok: false, error: msg };
+  }
 }
 
 export async function sendNotification(

--- a/packages/gateway/src/services/requirement.test.ts
+++ b/packages/gateway/src/services/requirement.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, mock, spyOn } from "bun:test";
 import { getDb, closeDb } from "../db";
 import {
   upsertUser,
   createWorkspace,
   addWorkspaceMember,
   updateRequirementDraft,
+  getRequirementDraft,
 } from "../db/queries";
 import {
   extractRequirementDraft,
@@ -13,6 +14,7 @@ import {
   patchDraft,
   getDraft,
   listDrafts,
+  finalizeDraft,
 } from "./requirement";
 
 // Pre-initialize DB before any git.test.ts fs mock can interfere with schema reads.
@@ -243,5 +245,111 @@ describe("requirement service (DB)", () => {
     const reviewing = listDrafts({ workspaceId, status: "review" });
     expect(reviewing.length).toBe(1);
     expect(reviewing[0].id).toBe(d1.id);
+  });
+});
+
+describe("finalizeDraft", () => {
+  let workspaceId: number;
+  let userId: number;
+  let userId2: number;
+
+  beforeEach(() => {
+    process.env.NODE_ENV = "test";
+    getDb();
+    const ws = createWorkspace({ name: "FinalizeWS", slug: `fin-ws-${Date.now()}` });
+    workspaceId = ws.id;
+    const user = upsertUser({ feishu_user_id: `fin-user-${Date.now()}`, name: "PM用户" });
+    userId = user.id;
+    const user2 = upsertUser({ feishu_user_id: `fin-user2-${Date.now()}`, name: "Other" });
+    userId2 = user2.id;
+    addWorkspaceMember(workspaceId, userId);
+  });
+
+  afterEach(() => {
+    closeDb();
+    mock.restore();
+  });
+
+  it("finalizeDraft succeeds for drafting status with sufficient prd_content", async () => {
+    const feishuService = await import("./feishu");
+    spyOn(feishuService, "sendRequirementReviewCard").mockResolvedValue({
+      ok: true,
+      card_id: "msg-test-001",
+    });
+
+    const draft = createDraft({ workspaceId, creatorId: userId, feishuChatId: "chat-test" });
+    updateRequirementDraft(draft.id, {
+      issue_title: "用户登录功能",
+      prd_content:
+        "# PRD\n\n## 功能描述\n\n支持用户通过手机号和验证码完成登录，兼容微信扫码登录。\n\n## 验收标准\n\n1. 支持手机号登录\n2. 支持微信扫码",
+    });
+
+    const result = await finalizeDraft({ draftId: draft.id, userId });
+    expect(result.ok).toBe(true);
+    expect(result.feishu_sent).toBe(true);
+    expect(result.draft?.status).toBe("review");
+
+    const updated = getRequirementDraft(draft.id);
+    expect(updated?.status).toBe("review");
+    expect(updated?.feishu_card_id).toBe("msg-test-001");
+  });
+
+  it("finalizeDraft returns error for non-drafting status", async () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    updateRequirementDraft(draft.id, { status: "review" });
+
+    const result = await finalizeDraft({ draftId: draft.id, userId });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("review");
+  });
+
+  it("finalizeDraft returns error when prd_content is too short", async () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    updateRequirementDraft(draft.id, {
+      issue_title: "标题",
+      prd_content: "太短",
+    });
+
+    const result = await finalizeDraft({ draftId: draft.id, userId });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("50");
+  });
+
+  it("finalizeDraft returns error for non-existent draft", async () => {
+    const result = await finalizeDraft({ draftId: 999999, userId });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("不存在");
+  });
+
+  it("finalizeDraft returns error for non-member", async () => {
+    const draft = createDraft({ workspaceId, creatorId: userId });
+    updateRequirementDraft(draft.id, {
+      prd_content:
+        "# PRD\n\n## 功能描述\n\n这是足够长的PRD内容，超过50个字符，用于测试权限校验场景下finalizeDraft的行为。",
+    });
+
+    const result = await finalizeDraft({ draftId: draft.id, userId: userId2 });
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain("无权限");
+  });
+
+  it("finalizeDraft succeeds even when feishu card send fails", async () => {
+    const feishuService = await import("./feishu");
+    spyOn(feishuService, "sendRequirementReviewCard").mockResolvedValue({
+      ok: false,
+      error: "飞书服务不可用",
+    });
+
+    const draft = createDraft({ workspaceId, creatorId: userId, feishuChatId: "chat-test" });
+    updateRequirementDraft(draft.id, {
+      issue_title: "测试功能",
+      prd_content:
+        "# PRD\n\n## 功能描述\n\n这是测试飞书发送失败时finalizeDraft仍然成功的场景，内容需要超过50个字符。",
+    });
+
+    const result = await finalizeDraft({ draftId: draft.id, userId });
+    expect(result.ok).toBe(true);
+    expect(result.feishu_sent).toBe(false);
+    expect(result.draft?.status).toBe("review");
   });
 });

--- a/packages/gateway/src/services/requirement.ts
+++ b/packages/gateway/src/services/requirement.ts
@@ -2,11 +2,13 @@ import { getConfig } from "../config";
 import {
   createRequirementDraft,
   getRequirementDraft,
+  getUserById,
   listRequirementDrafts,
   updateRequirementDraft,
   getWorkspaceMemberRole,
 } from "../db/queries";
 import { streamRequirementChatflow } from "./dify";
+import { sendRequirementReviewCard } from "./feishu";
 import type { RequirementDraft, RequirementDraftStatus } from "../types";
 
 // ─── Parser ────────────────────────────────────────────────────────────────────
@@ -212,4 +214,81 @@ export function listDrafts(params: {
     status: params.status,
     limit: params.limit,
   });
+}
+
+export async function finalizeDraft(params: {
+  draftId: number;
+  userId: number;
+}): Promise<{ ok: boolean; error?: string; draft?: RequirementDraft; feishu_sent?: boolean }> {
+  const draft = getRequirementDraft(params.draftId);
+  if (!draft) {
+    return { ok: false, error: "草稿不存在" };
+  }
+
+  if (draft.status !== "drafting") {
+    return {
+      ok: false,
+      error: `当前状态 "${draft.status}" 不允许提交 Review，仅 drafting 状态可提交`,
+    };
+  }
+
+  const memberRole = getWorkspaceMemberRole(draft.workspace_id, params.userId);
+  const isCreator = draft.creator_id === params.userId;
+  if (!isCreator && !memberRole) {
+    return { ok: false, error: "无权限操作此草稿" };
+  }
+
+  // 校验草稿内容非空且 prd_content 长度 > 50
+  const hasPrdContent = draft.prd_content && draft.prd_content.length > 50;
+  const hasBasicInfo = draft.issue_title || draft.issue_description;
+  if (!hasPrdContent && !hasBasicInfo) {
+    return {
+      ok: false,
+      error: "草稿内容不足，请先完成 PRD 内容（至少需要标题、描述或不少于50字的PRD正文）",
+    };
+  }
+  if (!hasPrdContent) {
+    return { ok: false, error: "PRD 正文内容不足（至少需要50个字符），请先完善 PRD 内容" };
+  }
+
+  // 状态切换到 review
+  updateRequirementDraft(params.draftId, { status: "review" });
+  const updated = getRequirementDraft(params.draftId)!;
+
+  // 发飞书卡片（失败不阻塞）
+  let feishu_sent = false;
+  const config = getConfig();
+  const chatId = draft.feishu_chat_id || config.feishuDefaultChatId;
+
+  if (chatId) {
+    try {
+      const creator = getUserById(draft.creator_id);
+      const creatorName = creator?.name || `用户 ${draft.creator_id}`;
+      const summary = (draft.prd_content || draft.issue_description || "")
+        .slice(0, 100)
+        .replace(/\n/g, " ");
+
+      const result = await sendRequirementReviewCard({
+        chatId,
+        draftId: params.draftId,
+        title: draft.issue_title || "（无标题）",
+        summary,
+        creatorName,
+        webBaseUrl: config.webBaseUrl,
+      });
+
+      if (result.ok) {
+        feishu_sent = true;
+        updateRequirementDraft(params.draftId, { feishu_card_id: result.card_id });
+      } else {
+        console.warn(`[finalizeDraft] 飞书卡片发送失败: ${result.error}`);
+      }
+    } catch (err) {
+      console.warn(`[finalizeDraft] 飞书卡片发送异常: ${err instanceof Error ? err.message : err}`);
+    }
+  } else {
+    console.warn("[finalizeDraft] 无飞书 chat_id，跳过卡片发送");
+  }
+
+  return { ok: true, draft: updated, feishu_sent };
 }

--- a/packages/gateway/src/test-config.ts
+++ b/packages/gateway/src/test-config.ts
@@ -34,6 +34,7 @@ export function createTestConfig(overrides?: Partial<Config>): Config {
     wikijsBaseUrl: "",
     wikijsApiKey: "",
     difyPrdGenApiKey: "",
+    difyRequirementChatApiKey: "",
     difyRagApiKey: "",
     difyDatasetApiKey: "",
     difyDatasetId: "",

--- a/packages/web/src/api/requirement.ts
+++ b/packages/web/src/api/requirement.ts
@@ -90,6 +90,17 @@ export function patchRequirementDraft(
   });
 }
 
+export interface FinalizeResult {
+  draft: RequirementDraft;
+  feishu_sent: boolean;
+}
+
+export function finalizeRequirementDraft(id: number): Promise<FinalizeResult> {
+  return request<FinalizeResult>(`/api/requirement/${id}/finalize`, {
+    method: "POST",
+  });
+}
+
 export type SSEChatEvent =
   | { type: "text"; content: string }
   | {

--- a/packages/web/src/pages/RequirementChat.vue
+++ b/packages/web/src/pages/RequirementChat.vue
@@ -361,7 +361,11 @@ const isReadonly = computed(() => {
   return s === "approved" || s === "rejected" || s === "abandoned";
 });
 
-const canFinalize = computed(() => store.currentDraft?.status === "drafting");
+const canFinalize = computed(() => {
+  const draft = store.currentDraft;
+  if (!draft || draft.status !== "drafting") return false;
+  return !!(draft.prd_content && draft.prd_content.length > 50);
+});
 
 function renderMd(content: string) {
   if (!content) return "";
@@ -439,9 +443,13 @@ async function handleSaveEdit() {
 
 async function handleFinalize() {
   if (!canFinalize.value) return;
-  const ok = await store.finalize();
-  if (ok) {
-    showToast("草稿已提交 Review");
+  const result = await store.finalize();
+  if (result.ok) {
+    if (result.feishu_sent === false) {
+      showToast("已提交，但飞书通知失败");
+    } else {
+      showToast("草稿已提交 Review");
+    }
   }
 }
 

--- a/packages/web/src/stores/requirement.ts
+++ b/packages/web/src/stores/requirement.ts
@@ -5,6 +5,7 @@ import {
   getRequirementDraft,
   listRequirementDrafts,
   patchRequirementDraft,
+  finalizeRequirementDraft,
   streamRequirementChat,
   type RequirementDraft,
   type RequirementDraftListResponse,
@@ -135,17 +136,17 @@ export const useRequirementStore = defineStore("requirement", () => {
     }
   }
 
-  async function finalize() {
-    if (!currentDraft.value) return false;
+  async function finalize(): Promise<{ ok: boolean; feishu_sent?: boolean }> {
+    if (!currentDraft.value) return { ok: false };
     loading.value = true;
     error.value = null;
     try {
-      const updated = await patchRequirementDraft(currentDraft.value.id, { status: "review" });
-      currentDraft.value = updated;
-      return true;
+      const result = await finalizeRequirementDraft(currentDraft.value.id);
+      currentDraft.value = result.draft;
+      return { ok: true, feishu_sent: result.feishu_sent };
     } catch (e) {
       error.value = e instanceof Error ? e.message : "提交失败";
-      return false;
+      return { ok: false };
     } finally {
       loading.value = false;
     }


### PR DESCRIPTION
P3 of #78. Gateway: finalize 接口 + 飞书卡片 + webhook 回调; Web: 按钮改调新接口. 测试 309 pass (+12), build/lint ✓. approve 回调 Stage D 落地在 P4.