### PR TITLE
feat(gateway): memory snapshot + approval token + nanoclaw dispatch (#93)

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "dev": "bun run --watch src/index.ts",
     "lint": "eslint src/ --max-warnings 0",
-    "test": "bun test --coverage --coverage-reporter lcov src/{index,config}.test.ts src/middleware/ src/routes/{api,auth,conversations,health,workspaces}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts && bun test src/db/ && bun test src/scheduler.test.ts src/services/workflow.test.ts && bun test src/routes/docs.test.ts && bun test src/routes/webhook.test.ts",
-    "test:all": "bun test --coverage --coverage-reporter lcov src/{index,config}.test.ts src/middleware/ src/db/ src/routes/{api,auth,conversations,health,workspaces}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts && bun test src/scheduler.test.ts src/services/workflow.test.ts && bun test src/routes/docs.test.ts && bun test src/routes/webhook.test.ts",
-    "test:coverage": "bun test --coverage src/{index,config}.test.ts src/middleware/ src/db/ src/routes/{api,auth,conversations,health,workspaces}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts"
+    "test": "bun test --coverage --coverage-reporter lcov src/{index,config}.test.ts src/middleware/ src/routes/{api,auth,conversations,health,workspaces,batch-2f}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts && bun test src/db/ && bun test src/scheduler.test.ts src/services/workflow.test.ts && bun test src/routes/docs.test.ts && bun test src/routes/webhook.test.ts",
+    "test:all": "bun test --coverage --coverage-reporter lcov src/{index,config}.test.ts src/middleware/ src/db/ src/routes/{api,auth,conversations,health,workspaces,batch-2f}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts && bun test src/scheduler.test.ts src/services/workflow.test.ts && bun test src/routes/docs.test.ts && bun test src/routes/webhook.test.ts",
+    "test:coverage": "bun test --coverage src/{index,config}.test.ts src/middleware/ src/db/ src/routes/{api,auth,conversations,health,workspaces,batch-2f}.test.ts src/services/{dify,feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts"
   },
   "dependencies": {
     "hono": "^4.0.0",

--- a/packages/gateway/src/db/queries.ts
+++ b/packages/gateway/src/db/queries.ts
@@ -614,3 +614,149 @@ export function updateRequirementDraft(
     .run(...values);
   return result.changes > 0;
 }
+
+// ----------------------------------------------------------------------------
+// Batch 2-F: user action log + approval token consumption + memory snapshot
+// ----------------------------------------------------------------------------
+
+export interface UserActionLog {
+  id: number;
+  user_id: number;
+  workspace_id: number | null;
+  action_type: string;
+  payload_json: string;
+  created_at: string;
+}
+
+export function recordUserAction(params: {
+  userId: number;
+  workspaceId?: number | null;
+  actionType: string;
+  payload?: unknown;
+}): void {
+  const db = getDb();
+  db.query(
+    `INSERT INTO user_action_log (user_id, workspace_id, action_type, payload_json)
+     VALUES (?, ?, ?, ?)`,
+  ).run(
+    params.userId,
+    params.workspaceId ?? null,
+    params.actionType,
+    JSON.stringify(params.payload ?? {}),
+  );
+}
+
+export function listRecentUserActions(params: {
+  workspaceId: number;
+  limit?: number;
+}): UserActionLog[] {
+  const db = getDb();
+  const rows = db
+    .query(
+      `SELECT id, user_id, workspace_id, action_type, payload_json, created_at
+       FROM user_action_log
+       WHERE workspace_id = ?
+       ORDER BY created_at DESC
+       LIMIT ?`,
+    )
+    .all(params.workspaceId, params.limit ?? 20) as UserActionLog[];
+  return rows;
+}
+
+/** Mark an approval token's jti as consumed. Returns false if already consumed. */
+export function markApprovalTokenConsumed(params: {
+  jti: string;
+  userId: number;
+  action: string;
+  resourceId: string;
+}): boolean {
+  const db = getDb();
+  try {
+    db.query(
+      `INSERT INTO approval_token_consumption (jti, user_id, action, resource_id)
+       VALUES (?, ?, ?, ?)`,
+    ).run(params.jti, params.userId, params.action, params.resourceId);
+    return true;
+  } catch {
+    // UNIQUE constraint → already consumed
+    return false;
+  }
+}
+
+export function isApprovalTokenConsumed(jti: string): boolean {
+  const db = getDb();
+  const row = db.query(`SELECT 1 FROM approval_token_consumption WHERE jti = ?`).get(jti);
+  return row !== null;
+}
+
+export interface MemorySnapshot {
+  workspace_id: number;
+  active_drafts: Array<{
+    id: number;
+    status: string;
+    issue_title: string;
+    updated_at: string;
+  }>;
+  running_workflows: Array<{
+    id: number;
+    workflow_type: string;
+    plane_issue_id: string | null;
+    status: string;
+    started_at: string | null;
+  }>;
+  recent_finalized: Array<{
+    id: number;
+    issue_title: string;
+    plane_issue_id: string | null;
+    approved_at: string | null;
+  }>;
+  recent_user_actions: UserActionLog[];
+  generated_at: string;
+}
+
+export function buildMemorySnapshot(workspaceId: number): MemorySnapshot {
+  const db = getDb();
+  const active_drafts = db
+    .query(
+      `SELECT id, status, issue_title, updated_at
+       FROM requirement_drafts
+       WHERE workspace_id = ? AND status IN ('drafting', 'review')
+       ORDER BY updated_at DESC
+       LIMIT 20`,
+    )
+    .all(workspaceId) as MemorySnapshot["active_drafts"];
+
+  const running_workflows = db
+    .query(
+      `SELECT id, workflow_type, plane_issue_id, status, started_at
+       FROM workflow_execution
+       WHERE status IN ('queued', 'running', 'pending')
+       ORDER BY created_at DESC
+       LIMIT 20`,
+    )
+    .all() as MemorySnapshot["running_workflows"];
+
+  const recent_finalized = db
+    .query(
+      `SELECT id, issue_title, plane_issue_id, approved_at
+       FROM requirement_drafts
+       WHERE workspace_id = ? AND status IN ('approved', 'review')
+       ORDER BY COALESCE(approved_at, updated_at) DESC
+       LIMIT 5`,
+    )
+    .all(workspaceId) as MemorySnapshot["recent_finalized"];
+
+  const recent_user_actions = listRecentUserActions({
+    workspaceId,
+    limit: 20,
+  });
+
+  return {
+    workspace_id: workspaceId,
+    active_drafts,
+    running_workflows,
+    recent_finalized,
+    recent_user_actions,
+    generated_at: new Date().toISOString(),
+  };
+}

--- a/packages/gateway/src/db/schema.sql
+++ b/packages/gateway/src/db/schema.sql
@@ -116,3 +116,26 @@ CREATE TABLE IF NOT EXISTS requirement_drafts (
 );
 CREATE INDEX IF NOT EXISTS idx_requirement_drafts_workspace ON requirement_drafts(workspace_id, status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_requirement_drafts_creator ON requirement_drafts(creator_id, updated_at DESC);
+
+-- Batch 2-F: Agent memory snapshot support — persists notable user actions so
+-- NanoClaw's memory_workspace_snapshot tool can surface "recent_user_actions".
+CREATE TABLE IF NOT EXISTS user_action_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  workspace_id INTEGER REFERENCES workspaces(id),
+  action_type TEXT NOT NULL,
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_user_action_log_user ON user_action_log(user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_user_action_log_workspace ON user_action_log(workspace_id, created_at DESC);
+
+-- Batch 2-F: one-time approval token consumption guard. Token jti recorded
+-- here becomes invalid for re-use even before its exp.
+CREATE TABLE IF NOT EXISTS approval_token_consumption (
+  jti TEXT PRIMARY KEY,
+  user_id INTEGER NOT NULL,
+  action TEXT NOT NULL,
+  resource_id TEXT NOT NULL,
+  consumed_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -11,6 +11,7 @@ import { conversationRoutes } from "./routes/conversations";
 import { workspaceRoutes } from "./routes/workspaces";
 import { planeProxyRoutes } from "./routes/plane-proxy";
 import { docsRoutes } from "./routes/docs";
+import { approvalRoutes } from "./routes/approval";
 import { startScheduler } from "./scheduler";
 
 // 初始化数据库
@@ -34,6 +35,7 @@ app.route("/api/conversations", conversationRoutes);
 app.route("/api/workspaces", workspaceRoutes);
 app.route("/api/plane", planeProxyRoutes);
 app.route("/api/docs", docsRoutes);
+app.route("/api/approval", approvalRoutes);
 
 // 启动调度器（非测试环境）
 if (process.env.NODE_ENV !== "test") {

--- a/packages/gateway/src/routes/api.ts
+++ b/packages/gateway/src/routes/api.ts
@@ -6,6 +6,9 @@ import {
   listWebhookLogs,
   createMessage,
   getWorkspace,
+  getWorkspaceMemberRole,
+  buildMemorySnapshot,
+  recordUserAction,
 } from "../db/queries";
 import { triggerWorkflow } from "../services/workflow";
 import {
@@ -388,4 +391,117 @@ apiRoutes.post("/requirement/:id/approve", async (c) => {
     prd_git_path: result.draft.prd_git_path,
     warning: result.warning,
   });
+});
+
+// ---------------------------------------------------------------------------
+// Batch 2-F: memory snapshot + nanoclaw dispatch
+// ---------------------------------------------------------------------------
+
+apiRoutes.use("/memory/*", authMiddleware);
+apiRoutes.get("/memory/snapshot", (c) => {
+  const userId = Number(c.get("userId" as never));
+  if (!userId) return c.json({ error: "Unauthorized" }, 401);
+  const wsRaw = c.req.query("workspace_id");
+  const workspaceId = Number(wsRaw);
+  if (!wsRaw || !Number.isFinite(workspaceId) || workspaceId <= 0) {
+    return c.json({ error: "workspace_id is required" }, 400);
+  }
+  // Authorization: caller must be a member of the workspace.
+  const role = getWorkspaceMemberRole(workspaceId, userId);
+  if (!role) return c.json({ error: "Not a workspace member" }, 403);
+
+  const snapshot = buildMemorySnapshot(workspaceId);
+  return c.json(snapshot);
+});
+
+/**
+ * POST /api/nanoclaw/dispatch
+ * Header: X-System-Secret (must match NANOCLAW_DISPATCH_SECRET)
+ * Body: { skill: string, workspace_id: number, plane_issue_id?: string,
+ *         user_id?: number, input?: unknown }
+ *
+ * Internal system-task entry. Called by Plane / webhook handlers when an
+ * automated workflow (e.g. Issue approved → prd_to_tech) needs to run an
+ * Agent skill without a live user. The Gateway forwards to NanoClaw's
+ * WebChannel as a system-identity message; NanoClaw loads the requested
+ * skill and executes.
+ *
+ * When NANOCLAW_URL is unset (dev / test), the request is persisted to
+ * user_action_log and echoed back for inspection.
+ */
+apiRoutes.post("/nanoclaw/dispatch", async (c) => {
+  const secret = c.req.header("X-System-Secret") ?? "";
+  const expected = process.env.NANOCLAW_DISPATCH_SECRET ?? "";
+  if (!expected) {
+    return c.json({ error: "NANOCLAW_DISPATCH_SECRET not configured" }, 503);
+  }
+  if (secret !== expected) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const body =
+    (await c.req.json<{
+      skill?: string;
+      workspace_id?: number;
+      plane_issue_id?: string;
+      user_id?: number;
+      input?: unknown;
+    }>()) ?? {};
+  if (!body.skill || !body.workspace_id) {
+    return c.json({ error: "skill and workspace_id are required" }, 400);
+  }
+
+  const dispatchId = `disp-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  recordUserAction({
+    userId: body.user_id ?? 0,
+    workspaceId: body.workspace_id,
+    actionType: `nanoclaw.dispatch.${body.skill}`,
+    payload: {
+      dispatch_id: dispatchId,
+      plane_issue_id: body.plane_issue_id,
+      input: body.input,
+    },
+  });
+
+  const nanoclawUrl = process.env.NANOCLAW_URL;
+  if (!nanoclawUrl) {
+    // Dev / test — do not attempt HTTP, just return the dispatch id.
+    return c.json({
+      ok: true,
+      dispatched: false,
+      dispatch_id: dispatchId,
+      reason: "NANOCLAW_URL not set — recorded only",
+    });
+  }
+
+  try {
+    const resp = await fetch(`${nanoclawUrl.replace(/\/+$/, "")}/api/chat`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-System-Secret": expected,
+      },
+      body: JSON.stringify({
+        client_id: `system-${dispatchId}`,
+        message: `[SYSTEM DISPATCH] run skill=${body.skill} workspace_id=${body.workspace_id} plane_issue_id=${body.plane_issue_id ?? ""}\n\n${JSON.stringify(body.input ?? {})}`,
+      }),
+    });
+    const ok = resp.ok;
+    return c.json({
+      ok,
+      dispatched: true,
+      dispatch_id: dispatchId,
+      nanoclaw_status: resp.status,
+    });
+  } catch (err) {
+    return c.json(
+      {
+        ok: false,
+        dispatched: false,
+        dispatch_id: dispatchId,
+        error: err instanceof Error ? err.message : "dispatch failed",
+      },
+      502,
+    );
+  }
 });

--- a/packages/gateway/src/routes/approval.ts
+++ b/packages/gateway/src/routes/approval.ts
@@ -1,0 +1,173 @@
+import { Hono } from "hono";
+import { authMiddleware } from "../middleware/auth";
+import {
+  consumeApprovalToken,
+  verifyApprovalToken,
+  type ApprovalAction,
+} from "../services/approval-token";
+import { getDb } from "../db";
+import { getWorkspaceMemberRole, recordUserAction, updateRequirementDraft } from "../db/queries";
+
+export const approvalRoutes = new Hono();
+
+/**
+ * POST /api/approval/verify
+ * Body: { token: string }
+ *
+ * Verify an approval token without consuming it. The Web confirmation page
+ * calls this on load so it can show the user what they're about to approve.
+ * Does NOT require user auth — the token itself is the bearer of identity.
+ */
+approvalRoutes.post("/verify", async (c) => {
+  const { token } = (await c.req.json<{ token?: string }>()) ?? {};
+  if (!token) return c.json({ ok: false, error: "token is required" }, 400);
+
+  const result = await verifyApprovalToken(token);
+  if (!result.ok) {
+    const status = result.code === "expired" || result.code === "already_consumed" ? 410 : 400;
+    return c.json({ ok: false, code: result.code, error: result.message }, status);
+  }
+  return c.json({ ok: true, payload: result.payload });
+});
+
+/**
+ * POST /api/approval/execute
+ * Headers: Authorization: Bearer <user JWT>
+ * Body: { token: string, note?: string }
+ *
+ * Atomically verify + consume an approval token and apply its action. Requires
+ * the caller's user JWT to match the token's user_id (so the same user who
+ * received the Feishu card must be the one clicking through).
+ */
+approvalRoutes.post("/execute", authMiddleware, async (c) => {
+  const callerUserId = Number(c.get("userId"));
+  const { token, note } =
+    (await c.req.json<{
+      token?: string;
+      note?: string;
+    }>()) ?? {};
+  if (!token) return c.json({ ok: false, error: "token is required" }, 400);
+
+  const result = await verifyApprovalToken(token);
+  if (!result.ok) {
+    const status = result.code === "expired" || result.code === "already_consumed" ? 410 : 400;
+    return c.json({ ok: false, code: result.code, error: result.message }, status);
+  }
+  const payload = result.payload;
+
+  if (payload.user_id !== callerUserId) {
+    return c.json(
+      {
+        ok: false,
+        code: "user_mismatch",
+        error: "token user does not match caller",
+      },
+      403,
+    );
+  }
+
+  // Consume first so racing double-click / double-submit can't both execute.
+  if (!consumeApprovalToken(payload)) {
+    return c.json(
+      {
+        ok: false,
+        code: "already_consumed",
+        error: "token already consumed",
+      },
+      410,
+    );
+  }
+
+  const outcome = await applyApproval(payload.resource_type, payload.resource_id, {
+    action: payload.action,
+    userId: callerUserId,
+    note,
+  });
+
+  if (!outcome.ok) {
+    return c.json(
+      {
+        ok: false,
+        code: "apply_failed",
+        error: outcome.error,
+      },
+      outcome.status,
+    );
+  }
+
+  recordUserAction({
+    userId: callerUserId,
+    workspaceId: outcome.workspaceId,
+    actionType: `approval.${payload.action}.${payload.resource_type}`,
+    payload: {
+      resource_id: payload.resource_id,
+      note,
+      via: "feishu_link",
+    },
+  });
+
+  return c.json({
+    ok: true,
+    action: payload.action,
+    resource: {
+      type: payload.resource_type,
+      id: payload.resource_id,
+    },
+  });
+});
+
+/**
+ * Dispatch table for approval resources. Add new resource types here when
+ * more card flows need cross-channel approval.
+ */
+async function applyApproval(
+  resourceType: string,
+  resourceId: string,
+  ctx: { action: ApprovalAction; userId: number; note?: string },
+): Promise<
+  | { ok: true; workspaceId: number | null }
+  | { ok: false; status: 400 | 403 | 404 | 500; error: string }
+> {
+  if (resourceType === "requirement_draft") {
+    const draftId = Number(resourceId);
+    if (!Number.isFinite(draftId)) {
+      return { ok: false, status: 400, error: "invalid draft id" };
+    }
+    const draft = getDb()
+      .query(
+        `SELECT id, workspace_id, creator_id, status
+         FROM requirement_drafts WHERE id = ?`,
+      )
+      .get(draftId) as {
+      id: number;
+      workspace_id: number;
+      creator_id: number;
+      status: string;
+    } | null;
+    if (!draft) {
+      return { ok: false, status: 404, error: "draft not found" };
+    }
+    if (draft.status !== "review" && draft.status !== "drafting") {
+      return {
+        ok: false,
+        status: 400,
+        error: `draft status ${draft.status} not approvable`,
+      };
+    }
+    const role = getWorkspaceMemberRole(draft.workspace_id, ctx.userId);
+    if (!role && draft.creator_id !== ctx.userId) {
+      return { ok: false, status: 403, error: "not a workspace member" };
+    }
+    const newStatus = ctx.action === "approve" ? "approved" : "rejected";
+    const ok = updateRequirementDraft(draftId, { status: newStatus });
+    if (!ok) {
+      return { ok: false, status: 500, error: "update failed" };
+    }
+    return { ok: true, workspaceId: draft.workspace_id };
+  }
+  return {
+    ok: false,
+    status: 400,
+    error: `unsupported resource_type: ${resourceType}`,
+  };
+}

--- a/packages/gateway/src/routes/batch-2f.test.ts
+++ b/packages/gateway/src/routes/batch-2f.test.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it, afterEach, beforeEach } from "bun:test";
+import { closeDb, getDb } from "../db";
+import { workspaceRoutes } from "./workspaces";
+import { approvalRoutes } from "./approval";
+import { apiRoutes } from "./api";
+import { signJwt } from "../services/auth";
+import {
+  signApprovalToken,
+  verifyApprovalToken,
+  consumeApprovalToken,
+} from "../services/approval-token";
+import {
+  upsertUser,
+  createWorkspace,
+  addWorkspaceMember,
+  updateRequirementDraft,
+  recordUserAction,
+  isApprovalTokenConsumed,
+  buildMemorySnapshot,
+  createWorkflowExecution,
+} from "../db/queries";
+import { createDraft } from "../services/requirement";
+
+describe("Batch 2-F: workspaces/:id/members/me", () => {
+  let token: string;
+  let userId: number;
+
+  beforeEach(async () => {
+    getDb();
+    const u = upsertUser({ feishu_user_id: "ou_b2f_ws", name: "b2f-ws" });
+    userId = u.id;
+    token = await signJwt({ sub: u.id, role: "member" });
+  });
+  afterEach(() => closeDb());
+
+  it("returns role + slug for a member", async () => {
+    const ws = createWorkspace({ name: "W", slug: "w-ms" });
+    addWorkspaceMember(ws.id, userId, "admin");
+
+    const res = await workspaceRoutes.request(`/${ws.id}/members/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      user_id: userId,
+      workspace_id: ws.id,
+      role: "admin",
+      workspace_slug: "w-ms",
+    });
+  });
+
+  it("returns 403 for non-member", async () => {
+    const ws = createWorkspace({ name: "W2", slug: "w-nm" });
+    const res = await workspaceRoutes.request(`/${ws.id}/members/me`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 without Bearer token", async () => {
+    const res = await workspaceRoutes.request(`/1/members/me`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("Batch 2-F: approval tokens", () => {
+  let userId: number;
+  let userToken: string;
+  let draftId: number;
+  let wsId: number;
+
+  beforeEach(async () => {
+    getDb();
+    const u = upsertUser({ feishu_user_id: "ou_b2f_appr", name: "b2f-appr" });
+    userId = u.id;
+    userToken = await signJwt({ sub: u.id, role: "admin" });
+    const ws = createWorkspace({ name: "AP", slug: "ap-ws" });
+    wsId = ws.id;
+    addWorkspaceMember(ws.id, userId, "admin");
+    draftId = createDraft({ workspaceId: ws.id, creatorId: userId }).id;
+    updateRequirementDraft(draftId, { status: "review" });
+  });
+  afterEach(() => closeDb());
+
+  it("signs + verifies + consumes (one-shot)", async () => {
+    const tok = await signApprovalToken({
+      userId,
+      action: "approve",
+      resourceType: "requirement_draft",
+      resourceId: String(draftId),
+    });
+
+    const first = await verifyApprovalToken(tok);
+    if (!first.ok) throw new Error("expected verify ok");
+    expect(first.payload.action).toBe("approve");
+
+    const consumed = consumeApprovalToken(first.payload);
+    expect(consumed).toBe(true);
+    expect(isApprovalTokenConsumed(first.payload.jti)).toBe(true);
+
+    const second = consumeApprovalToken(first.payload);
+    expect(second).toBe(false);
+
+    const reverify = await verifyApprovalToken(tok);
+    expect(reverify.ok).toBe(false);
+    if (!reverify.ok) expect(reverify.code).toBe("already_consumed");
+  });
+
+  it("POST /verify rejects bad token", async () => {
+    const res = await approvalRoutes.request("/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "not.a.jwt" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /verify accepts valid token without consuming", async () => {
+    const tok = await signApprovalToken({
+      userId,
+      action: "approve",
+      resourceType: "requirement_draft",
+      resourceId: String(draftId),
+    });
+    const res = await approvalRoutes.request("/verify", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: tok }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.payload.action).toBe("approve");
+
+    // Not yet consumed.
+    const again = await verifyApprovalToken(tok);
+    expect(again.ok).toBe(true);
+  });
+
+  it("POST /execute applies approve and marks consumed", async () => {
+    const tok = await signApprovalToken({
+      userId,
+      action: "approve",
+      resourceType: "requirement_draft",
+      resourceId: String(draftId),
+    });
+    const res = await approvalRoutes.request("/execute", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ token: tok, note: "looks good" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.action).toBe("approve");
+
+    // Draft now approved.
+    const row = getDb()
+      .query("SELECT status FROM requirement_drafts WHERE id = ?")
+      .get(draftId) as { status: string };
+    expect(row.status).toBe("approved");
+
+    // Second attempt returns 410 already_consumed.
+    const res2 = await approvalRoutes.request("/execute", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${userToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ token: tok }),
+    });
+    expect(res2.status).toBe(410);
+  });
+
+  it("POST /execute refuses when caller != token user", async () => {
+    const other = upsertUser({ feishu_user_id: "ou_b2f_other", name: "other" });
+    const otherToken = await signJwt({ sub: other.id, role: "member" });
+    addWorkspaceMember(wsId, other.id, "member");
+
+    const tok = await signApprovalToken({
+      userId,
+      action: "reject",
+      resourceType: "requirement_draft",
+      resourceId: String(draftId),
+    });
+    const res = await approvalRoutes.request("/execute", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${otherToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ token: tok }),
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("Batch 2-F: /api/memory/snapshot", () => {
+  let userId: number;
+  let token: string;
+  let wsId: number;
+
+  beforeEach(async () => {
+    getDb();
+    const u = upsertUser({ feishu_user_id: "ou_b2f_mem", name: "b2f-mem" });
+    userId = u.id;
+    token = await signJwt({ sub: u.id, role: "admin" });
+    const ws = createWorkspace({ name: "M", slug: "m-ws" });
+    wsId = ws.id;
+    addWorkspaceMember(ws.id, userId, "admin");
+  });
+  afterEach(() => closeDb());
+
+  it("aggregates drafts + workflows + user actions", async () => {
+    const d = createDraft({ workspaceId: wsId, creatorId: userId });
+    updateRequirementDraft(d.id, {
+      issue_title: "T1",
+      status: "review",
+    });
+    createWorkflowExecution({
+      workflow_type: "prd_to_tech",
+      trigger_source: "manual",
+      plane_issue_id: "ISS-1",
+    });
+    recordUserAction({
+      userId,
+      workspaceId: wsId,
+      actionType: "test.action",
+      payload: { foo: "bar" },
+    });
+
+    const snap = buildMemorySnapshot(wsId);
+    expect(snap.workspace_id).toBe(wsId);
+    expect(snap.active_drafts.length).toBe(1);
+    expect(snap.active_drafts[0].issue_title).toBe("T1");
+    expect(snap.running_workflows.length).toBeGreaterThan(0);
+    expect(snap.recent_user_actions.length).toBe(1);
+    expect(snap.recent_user_actions[0].action_type).toBe("test.action");
+  });
+
+  it("GET endpoint requires workspace_id and membership", async () => {
+    const res1 = await apiRoutes.request("/memory/snapshot", {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res1.status).toBe(400);
+
+    const res2 = await apiRoutes.request(`/memory/snapshot?workspace_id=${wsId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res2.status).toBe(200);
+    const body = await res2.json();
+    expect(body.workspace_id).toBe(wsId);
+  });
+
+  it("returns 403 for non-member workspace", async () => {
+    const other = createWorkspace({ name: "Other", slug: "other-ws" });
+    const res = await apiRoutes.request(`/memory/snapshot?workspace_id=${other.id}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("Batch 2-F: /api/nanoclaw/dispatch", () => {
+  const originalUrl = process.env.NANOCLAW_URL;
+  const originalSecret = process.env.NANOCLAW_DISPATCH_SECRET;
+
+  beforeEach(() => {
+    getDb();
+    process.env.NANOCLAW_DISPATCH_SECRET = "test-secret";
+    delete process.env.NANOCLAW_URL;
+  });
+  afterEach(() => {
+    closeDb();
+    if (originalUrl) process.env.NANOCLAW_URL = originalUrl;
+    else delete process.env.NANOCLAW_URL;
+    if (originalSecret) process.env.NANOCLAW_DISPATCH_SECRET = originalSecret;
+    else delete process.env.NANOCLAW_DISPATCH_SECRET;
+  });
+
+  it("503 when secret not configured", async () => {
+    delete process.env.NANOCLAW_DISPATCH_SECRET;
+    const res = await apiRoutes.request("/nanoclaw/dispatch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  it("403 when X-System-Secret missing/mismatched", async () => {
+    const res = await apiRoutes.request("/nanoclaw/dispatch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-System-Secret": "wrong",
+      },
+      body: JSON.stringify({ skill: "x", workspace_id: 1 }),
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("400 when skill / workspace_id missing", async () => {
+    const res = await apiRoutes.request("/nanoclaw/dispatch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-System-Secret": "test-secret",
+      },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("records action and returns dispatch_id when NANOCLAW_URL unset", async () => {
+    const u = upsertUser({ feishu_user_id: "ou_b2f_disp", name: "disp" });
+    const ws = createWorkspace({ name: "D", slug: "d-ws" });
+    const res = await apiRoutes.request("/nanoclaw/dispatch", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-System-Secret": "test-secret",
+      },
+      body: JSON.stringify({
+        skill: "arcflow-tech-design",
+        workspace_id: ws.id,
+        plane_issue_id: "ISS-42",
+        user_id: u.id,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.dispatched).toBe(false);
+    expect(body.dispatch_id).toMatch(/^disp-/);
+
+    const actions = buildMemorySnapshot(ws.id).recent_user_actions;
+    expect(actions[0].action_type).toBe("nanoclaw.dispatch.arcflow-tech-design");
+  });
+});

--- a/packages/gateway/src/routes/docs.ts
+++ b/packages/gateway/src/routes/docs.ts
@@ -76,6 +76,34 @@ export function createDocsRoutes(overrides?: Partial<DocsRouteDeps>): Hono {
     await deps.ensureRepoByUrl(repoDir, repoUrl);
   }
 
+  /**
+   * GET /api/docs?type=<prd|tech-design|api|arch|ops|market>&q=<keyword>
+   *
+   * Unified docs index used by NanoClaw arcflow-knowledge. When `q` is set,
+   * runs a search scoped to the docs repo; when `type` is set, filters
+   * results by path prefix. With neither, returns the root tree.
+   */
+  router.get("/", async (c) => {
+    const type = c.req.query("type");
+    const q = c.req.query("q");
+    const { repoName, repoUrl } = getDocsRepoInfo(c);
+    if (!repoUrl) return c.json({ data: [] });
+    await ensureWorkspaceDocs(repoName, repoUrl);
+
+    if (q?.trim()) {
+      const raw = await deps.searchFiles(repoName, q);
+      const data = type
+        ? (raw as Array<{ path?: string }>).filter((r) => (r.path ?? "").startsWith(`${type}/`))
+        : raw;
+      return c.json({ data });
+    }
+    const tree = await deps.listTree(repoName);
+    const data = type
+      ? (tree as Array<{ path?: string }>).filter((r) => (r.path ?? "").startsWith(`${type}/`))
+      : tree;
+    return c.json({ data });
+  });
+
   router.get("/tree", async (c) => {
     const { repoName, repoUrl } = getDocsRepoInfo(c);
     if (!repoUrl) return c.json({ data: [] });

--- a/packages/gateway/src/routes/workspaces.ts
+++ b/packages/gateway/src/routes/workspaces.ts
@@ -43,6 +43,27 @@ workspaceRoutes.get("/:id", (c) => {
   return c.json({ ...workspace, members, user_role: role });
 });
 
+/**
+ * GET /api/workspaces/:id/members/me
+ * Lightweight membership probe called by NanoClaw WebChannel to cache
+ * (user_id, workspace_id) → role. Returns 200 with {role, workspace_slug}
+ * on membership, 403 on non-member.
+ */
+workspaceRoutes.get("/:id/members/me", (c) => {
+  const userId = c.get("userId") as number;
+  const id = Number(c.req.param("id"));
+  if (!Number.isFinite(id)) return c.json({ error: "Invalid ID" }, 400);
+  const role = getWorkspaceMemberRole(id, userId);
+  if (!role) return c.json({ error: "not_a_member" }, 403);
+  const workspace = getWorkspace(id);
+  return c.json({
+    user_id: userId,
+    workspace_id: id,
+    role,
+    workspace_slug: workspace?.slug ?? null,
+  });
+});
+
 workspaceRoutes.patch("/:id/settings", async (c) => {
   const userId = c.get("userId") as number;
   const id = Number(c.req.param("id"));

--- a/packages/gateway/src/services/approval-token.ts
+++ b/packages/gateway/src/services/approval-token.ts
@@ -1,0 +1,110 @@
+import { SignJWT, jwtVerify } from "jose";
+import { randomUUID } from "crypto";
+import { getConfig } from "../config";
+import { isApprovalTokenConsumed, markApprovalTokenConsumed } from "../db/queries";
+
+/**
+ * Approval token — a short-lived one-shot JWT embedded in Feishu cards so the
+ * user can click a link and approve/reject a resource via the Web UI. Since
+ * Feishu can't call Gateway directly (outbound-only network), we don't do
+ * reverse callbacks — the user's browser opens a link carrying this token,
+ * hits the Web confirmation page, which then calls /api/approval/execute.
+ */
+
+export type ApprovalAction = "approve" | "reject";
+
+export interface ApprovalTokenPayload {
+  user_id: number;
+  action: ApprovalAction;
+  resource_type: string;
+  resource_id: string;
+  jti: string;
+  exp?: number;
+  iat?: number;
+}
+
+const TOKEN_TTL_SECONDS = 15 * 60;
+
+export async function signApprovalToken(params: {
+  userId: number;
+  action: ApprovalAction;
+  resourceType: string;
+  resourceId: string;
+  ttlSeconds?: number;
+}): Promise<string> {
+  const config = getConfig();
+  const secret = new TextEncoder().encode(config.jwtSecret);
+  const ttl = params.ttlSeconds ?? TOKEN_TTL_SECONDS;
+  const jti = randomUUID();
+  return new SignJWT({
+    user_id: params.userId,
+    action: params.action,
+    resource_type: params.resourceType,
+    resource_id: params.resourceId,
+    jti,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setIssuedAt()
+    .setExpirationTime(`${ttl}s`)
+    .sign(secret);
+}
+
+export type ApprovalVerifyResult =
+  | { ok: true; payload: ApprovalTokenPayload }
+  | {
+      ok: false;
+      code: "invalid" | "expired" | "already_consumed" | "malformed";
+      message: string;
+    };
+
+/**
+ * Verify a token without consuming it. Safe to call multiple times (e.g. the
+ * confirmation page loads, the user clicks confirm → /execute is called
+ * separately).
+ */
+export async function verifyApprovalToken(token: string): Promise<ApprovalVerifyResult> {
+  const config = getConfig();
+  const secret = new TextEncoder().encode(config.jwtSecret);
+  let payload: ApprovalTokenPayload;
+  try {
+    const res = await jwtVerify(token, secret);
+    payload = res.payload as unknown as ApprovalTokenPayload;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : "invalid";
+    if (/exp/i.test(msg)) {
+      return { ok: false, code: "expired", message: "token expired" };
+    }
+    return { ok: false, code: "invalid", message: "invalid token" };
+  }
+
+  if (
+    typeof payload.user_id !== "number" ||
+    !payload.action ||
+    !payload.resource_type ||
+    !payload.resource_id ||
+    !payload.jti
+  ) {
+    return { ok: false, code: "malformed", message: "missing required claims" };
+  }
+  if (isApprovalTokenConsumed(payload.jti)) {
+    return {
+      ok: false,
+      code: "already_consumed",
+      message: "token already consumed",
+    };
+  }
+  return { ok: true, payload };
+}
+
+/**
+ * Atomically mark a token consumed. Returns false if it was already consumed
+ * (race-safe — relies on UNIQUE constraint).
+ */
+export function consumeApprovalToken(payload: ApprovalTokenPayload): boolean {
+  return markApprovalTokenConsumed({
+    jti: payload.jti,
+    userId: payload.user_id,
+    action: payload.action,
+    resourceId: payload.resource_id,
+  });
+}

--- a/packages/gateway/src/services/dify.ts
+++ b/packages/gateway/src/services/dify.ts
@@ -1,3 +1,9 @@
+/**
+ * @deprecated Batch 2-F. Dify integration is scheduled for removal in Batch 5
+ * (spec §7). Do not add new callers. NanoClaw arcflow-* skills now handle
+ * PRD → tech-design, tech-design → OpenAPI, CI log → bug report, and
+ * RAG-style Q&A via the Agent's native Read/Grep/WebFetch + MemPalace.
+ */
 import { getConfig } from "../config";
 import { parseDifySSEChunk } from "./prd";
 import type { DifySSEChunk } from "./prd";


### PR DESCRIPTION
## Summary
Batch 2-F — Gateway 侧补齐 NanoClaw 架构所需的系统端点，spec §4.8 §7.3 §8。

**新增端点**：
- `GET /api/memory/snapshot?workspace_id=` — Agent 操作态快照
- `GET /api/workspaces/:id/members/me` — WebChannel 权限缓存源
- `POST /api/approval/verify` + `/execute` — 飞书卡片跳 Web 的一次性 JWT 审批
- `POST /api/nanoclaw/dispatch` — 系统任务派发入口 (X-System-Secret 鉴权)
- `GET /api/docs?type=&q=` — arcflow-knowledge 用的索引形态

**新增**：
- `services/approval-token.ts` — 15min HS256 JWT + jti 防重放
- `user_action_log` 表 + `approval_token_consumption` 表
- `services/dify.ts` 头部 `@deprecated` 注释

## Test plan
- [x] `bun run lint` 通过 (无 warning)
- [x] `bun run test` — 300+ tests 全绿 (新增 batch-2f.test.ts 15 用例：members/me / approval token 全流程 / memory snapshot / dispatch 鉴权)
- [ ] 端到端 dispatch 到 nanoclaw 手测（需 nanoclaw 服务在线）

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)