### PR TITLE
feat(gateway/web): 飞书审批链接改造 (#90)

### DIFF
--- a/packages/gateway/src/routes/webhook.test.ts
+++ b/packages/gateway/src/routes/webhook.test.ts
@@ -206,7 +206,10 @@ describe("webhook routes", () => {
     expect(body.source).toBe("feishu");
   });
 
-  it("POST /webhook/feishu triggers code_gen on approve action", async () => {
+  it("POST /webhook/feishu ignores legacy card action callbacks (Batch 4-I)", async () => {
+    // Card reverse callbacks are no longer supported — cards now use Web
+    // redirect links carrying approval tokens. The endpoint stays only to
+    // answer Feishu's URL verification challenge.
     const actionValue = JSON.stringify({
       action: "approve",
       issue_id: "ISS-50",
@@ -214,24 +217,15 @@ describe("webhook routes", () => {
       workspace_id: 7,
     });
 
-    await app.request("/webhook/feishu", {
+    const res = await app.request("/webhook/feishu", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        action: { value: actionValue },
-      }),
+      body: JSON.stringify({ action: { value: actionValue } }),
     });
-
-    expect(triggerSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        workspace_id: 7,
-        workflow_type: "code_gen",
-        trigger_source: "manual",
-        plane_issue_id: "ISS-50",
-        input_path: "tech-design/2026-04/login.md",
-        target_repos: ["backend"],
-      }),
-    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.handled).toBe(false);
+    expect(triggerSpy).not.toHaveBeenCalled();
   });
 
   it("POST /webhook/feishu does not trigger on reject action", async () => {
@@ -415,234 +409,5 @@ describe("webhook routes", () => {
         trigger_source: "ibuild_webhook",
       }),
     );
-  });
-});
-
-describe("feishu webhook - requirement callbacks", () => {
-  let app: Hono;
-
-  beforeEach(async () => {
-    process.env.NODE_ENV = "test";
-    configOverrides = {};
-    getDb();
-    app = new Hono();
-    app.route("/webhook", createWebhookRoutes());
-    spyOn(workflowService, "triggerWorkflow").mockResolvedValue(1);
-    spyOn(ibuildLogFetcher, "fetchBuildLogWithContext").mockResolvedValue("mocked build log");
-  });
-
-  afterEach(() => {
-    closeDb();
-    mock.restore();
-    configOverrides = {};
-  });
-
-  async function seedDraftInReview() {
-    const {
-      createWorkspace,
-      upsertUser,
-      createRequirementDraft,
-      updateRequirementDraft,
-      updateWorkspaceSettings,
-    } = await import("../db/queries");
-    const ws = createWorkspace({ name: "ReqWS", slug: `req-ws-${Date.now()}` });
-    updateWorkspaceSettings(ws.id, {
-      plane_project_id: "proj-req-1",
-      plane_workspace_slug: "req-slug",
-    });
-    const user = upsertUser({ feishu_user_id: `req-user-${Date.now()}`, name: "PM" });
-    const draft = createRequirementDraft({
-      workspace_id: ws.id,
-      creator_id: user.id,
-      feishu_chat_id: "chat-req-test",
-    });
-    updateRequirementDraft(draft.id, {
-      status: "review",
-      issue_title: "用户登录",
-      feishu_card_id: "msg-card-001",
-    });
-    return { draft, ws, user };
-  }
-
-  async function mockStageD() {
-    const gitService = await import("../services/git");
-    const planeService = await import("../services/plane");
-    spyOn(gitService, "ensureRepo").mockResolvedValue({} as never);
-    spyOn(gitService, "writeAndPush").mockResolvedValue(undefined);
-    spyOn(planeService, "createIssue").mockResolvedValue({ id: "plane-issue-webhook" });
-    spyOn(planeService, "updateIssueState").mockResolvedValue(undefined);
-  }
-
-  it("POST /webhook/feishu requirement_approve updates status to approved", async () => {
-    const feishuService = await import("../services/feishu");
-    spyOn(feishuService, "updateCard").mockResolvedValue();
-    await mockStageD();
-
-    const { draft } = await seedDraftInReview();
-
-    const actionValue = JSON.stringify({
-      type: "requirement_approve",
-      draft_id: draft.id,
-    });
-
-    const res = await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-    expect(res.status).toBe(200);
-
-    // approveDraft is async (fire-and-forget), flush microtask queue
-    await Bun.sleep(10);
-
-    const { getRequirementDraft } = await import("../db/queries");
-    const updated = getRequirementDraft(draft.id);
-    expect(updated?.status).toBe("approved");
-  });
-
-  it("POST /webhook/feishu requirement_reject updates status to rejected", async () => {
-    const feishuService = await import("../services/feishu");
-    spyOn(feishuService, "updateCard").mockResolvedValue();
-
-    const { draft } = await seedDraftInReview();
-
-    const actionValue = JSON.stringify({
-      type: "requirement_reject",
-      draft_id: draft.id,
-    });
-
-    const res = await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-    expect(res.status).toBe(200);
-
-    const { getRequirementDraft } = await import("../db/queries");
-    const updated = getRequirementDraft(draft.id);
-    expect(updated?.status).toBe("rejected");
-  });
-
-  it("POST /webhook/feishu requirement_approve calls updateCard when feishu_card_id present", async () => {
-    const feishuService = await import("../services/feishu");
-    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
-    await mockStageD();
-
-    const { draft } = await seedDraftInReview();
-
-    const actionValue = JSON.stringify({
-      type: "requirement_approve",
-      draft_id: draft.id,
-    });
-
-    await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-
-    await Bun.sleep(10); // flush promise queue for async approveDraft + updateCard
-
-    expect(updateCardSpy).toHaveBeenCalledWith(
-      "msg-card-001",
-      expect.objectContaining({
-        header: expect.objectContaining({
-          template: "green",
-        }),
-      }),
-    );
-  });
-
-  it("POST /webhook/feishu requirement_reject calls updateCard when feishu_card_id present", async () => {
-    const feishuService = await import("../services/feishu");
-    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
-
-    const { draft } = await seedDraftInReview();
-
-    const actionValue = JSON.stringify({
-      type: "requirement_reject",
-      draft_id: draft.id,
-    });
-
-    await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-
-    await Bun.sleep(0);
-
-    expect(updateCardSpy).toHaveBeenCalledWith(
-      "msg-card-001",
-      expect.objectContaining({
-        header: expect.objectContaining({
-          template: "red",
-        }),
-      }),
-    );
-  });
-
-  it("POST /webhook/feishu requirement_approve shows error card when approveDraft fails (prereq)", async () => {
-    const feishuService = await import("../services/feishu");
-    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
-
-    // seedDraftInReview sets up workspace WITHOUT plane config to force prereq error
-    const { createWorkspace, upsertUser, createRequirementDraft, updateRequirementDraft } =
-      await import("../db/queries");
-    const ws = createWorkspace({ name: "NoPlaneWS", slug: `no-plane-${Date.now()}` });
-    // intentionally NOT setting plane_project_id
-    const user = upsertUser({ feishu_user_id: `np-user-${Date.now()}`, name: "NP" });
-    const draft = createRequirementDraft({ workspace_id: ws.id, creator_id: user.id });
-    updateRequirementDraft(draft.id, {
-      status: "review",
-      issue_title: "测试失败",
-      feishu_card_id: "msg-card-fail",
-    });
-
-    const actionValue = JSON.stringify({ type: "requirement_approve", draft_id: draft.id });
-    await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-
-    await Bun.sleep(10); // flush async approveDraft promise
-
-    // Should show error card (yellow template)
-    expect(updateCardSpy).toHaveBeenCalledWith(
-      "msg-card-fail",
-      expect.objectContaining({
-        header: expect.objectContaining({ template: "yellow" }),
-      }),
-    );
-
-    // Status should remain "review" since approveDraft failed
-    const { getRequirementDraft } = await import("../db/queries");
-    const dbDraft = getRequirementDraft(draft.id);
-    expect(dbDraft?.status).toBe("review");
-  });
-
-  it("POST /webhook/feishu requirement_approve does nothing when draft not in review status", async () => {
-    await mockStageD();
-    const feishuService = await import("../services/feishu");
-    const updateCardSpy = spyOn(feishuService, "updateCard").mockResolvedValue();
-
-    const { createWorkspace, upsertUser, createRequirementDraft } = await import("../db/queries");
-    const ws = createWorkspace({ name: "WS2", slug: `ws2-${Date.now()}` });
-    const user = upsertUser({ feishu_user_id: `user2-${Date.now()}`, name: "U2" });
-    const draft = createRequirementDraft({ workspace_id: ws.id, creator_id: user.id });
-    // status stays "drafting" (not "review")
-
-    const actionValue = JSON.stringify({ type: "requirement_approve", draft_id: draft.id });
-    const res = await app.request("/webhook/feishu", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ action: { value: actionValue } }),
-    });
-    expect(res.status).toBe(200);
-
-    // webhook skips non-review drafts in the outer `if (draft && draft.status === "review")` check
-    await Bun.sleep(0);
-    expect(updateCardSpy).not.toHaveBeenCalled();
   });
 });

--- a/packages/gateway/src/routes/webhook.ts
+++ b/packages/gateway/src/routes/webhook.ts
@@ -7,8 +7,6 @@ import {
   isEventProcessed,
   recordWebhookEvent,
   recordWebhookLog,
-  getRequirementDraft,
-  updateRequirementDraft,
   findRequirementDraftByPlaneIssue,
   getWorkspaceByPlaneProject,
   getWorkspaceBySlug,
@@ -18,8 +16,6 @@ import { fetchBuildLogWithContext } from "../services/ibuild-log-fetcher";
 import { shouldTriggerWorkflow, extractPrdPath } from "../services/plane-webhook";
 import type { PlaneWebhookPayload } from "../services/plane-webhook";
 import { syncRecentChanges } from "../services/rag-sync";
-import { updateCard } from "../services/feishu";
-import { approveDraft } from "../services/requirement";
 
 export function createWebhookRoutes(): Hono {
   const config = getConfig();
@@ -122,128 +118,19 @@ export function createWebhookRoutes(): Hono {
     },
   );
 
-  // Feishu callback: approval button clicks
+  // Feishu callback endpoint.
+  // Batch 4-I (spec §8): internal network is outbound-only, so card button
+  // reverse callbacks are no longer supported. Cards now ship Web redirect
+  // links carrying short-lived approval tokens — the user's browser hits
+  // /api/approval/execute directly. We keep this endpoint only to answer
+  // Feishu's URL verification challenge during app setup.
   webhookRoutes.post("/feishu", async (c) => {
     const body = await c.req.json();
-
-    // Feishu URL verification challenge
     if (body.type === "url_verification") {
       return c.json({ challenge: body.challenge });
     }
-
-    // Parse Feishu card action callback
-    const action = body.action;
-    if (action?.value) {
-      try {
-        const value = JSON.parse(action.value);
-        const actionType = value.action; // "approve" or "reject" (tech review)
-        const callbackType = value.type; // "requirement_approve" or "requirement_reject"
-        const issueId = value.issue_id;
-
-        // ── 需求 PRD Review 回调 ──────────────────────────────────────────
-        if (callbackType === "requirement_approve" || callbackType === "requirement_reject") {
-          const draftId = Number(value.draft_id);
-          if (draftId) {
-            const draft = getRequirementDraft(draftId);
-            if (draft && draft.status === "review") {
-              if (callbackType === "requirement_approve") {
-                // P4: Stage D — 执行五步原子操作
-                approveDraft({ draftId, source: "feishu" })
-                  .then((result) => {
-                    if (!result.ok) {
-                      console.error(
-                        `[feishu webhook] approveDraft failed (draftId=${draftId}, step=${result.step}): ${result.error}`,
-                      );
-                      // 审批失败时更新卡片显示错误
-                      if (draft.feishu_card_id) {
-                        const errorCard = {
-                          config: { wide_screen_mode: true },
-                          header: {
-                            title: { tag: "plain_text", content: "⚠️ 需求 PRD 审批落地失败" },
-                            template: "yellow",
-                          },
-                          elements: [
-                            {
-                              tag: "div",
-                              text: {
-                                tag: "lark_md",
-                                content: `**标题：** ${draft.issue_title || "（无标题）"}\n\n审批操作失败（步骤: ${result.step ?? "unknown"}）：${result.error}\n\n请联系管理员检查配置后重试。`,
-                              },
-                            },
-                          ],
-                        };
-                        updateCard(draft.feishu_card_id, errorCard).catch((err) => {
-                          console.warn(
-                            `[feishu webhook] 更新卡片失败: ${err instanceof Error ? err.message : err}`,
-                          );
-                        });
-                      }
-                    } else {
-                      console.log(
-                        `[feishu webhook] requirement draft ${draftId} approved via Stage D`,
-                      );
-                      if (result.warning) {
-                        console.warn(`[feishu webhook] approveDraft warning: ${result.warning}`);
-                      }
-                    }
-                  })
-                  .catch((err) => {
-                    console.error(
-                      `[feishu webhook] approveDraft threw (draftId=${draftId}): ${err instanceof Error ? err.message : err}`,
-                    );
-                  });
-              } else {
-                // requirement_reject
-                updateRequirementDraft(draftId, { status: "rejected" });
-                console.log(`[feishu webhook] requirement draft ${draftId} rejected`);
-
-                if (draft.feishu_card_id) {
-                  const rejectedCard = {
-                    config: { wide_screen_mode: true },
-                    header: {
-                      title: { tag: "plain_text", content: "❌ 需求 PRD 已驳回" },
-                      template: "red",
-                    },
-                    elements: [
-                      {
-                        tag: "div",
-                        text: {
-                          tag: "lark_md",
-                          content: `**标题：** ${draft.issue_title || "（无标题）"}\n\n已驳回，请 PM 修改后重新提交。`,
-                        },
-                      },
-                    ],
-                  };
-                  updateCard(draft.feishu_card_id, rejectedCard).catch((err) => {
-                    console.warn(
-                      `[feishu webhook] 更新卡片失败: ${err instanceof Error ? err.message : err}`,
-                    );
-                  });
-                }
-              }
-            }
-          }
-        }
-
-        // ── 技术文档 Review 回调（原有逻辑） ────────────────────────────
-        if (actionType === "approve" && issueId && value.workspace_id) {
-          // Trigger code generation
-          triggerWorkflow({
-            workspace_id: Number(value.workspace_id),
-            workflow_type: "code_gen",
-            trigger_source: "manual",
-            plane_issue_id: issueId,
-            input_path: value.doc_path,
-            target_repos: ["backend"],
-          });
-        }
-        // reject is handled by updateIssueState in the workflow
-      } catch {
-        // Invalid action value, ignore
-      }
-    }
-
-    return c.json({ received: true, source: "feishu" });
+    // Ignore all other callbacks (including stale card clicks from old cards).
+    return c.json({ received: true, source: "feishu", handled: false });
   });
 
   // iBuild: 构建失败 → Bug 分析

--- a/packages/gateway/src/services/feishu.test.ts
+++ b/packages/gateway/src/services/feishu.test.ts
@@ -234,6 +234,7 @@ describe("feishu service", () => {
         summary: "支持手机号验证码登录",
         creatorName: "张三",
         webBaseUrl: "http://localhost:5173",
+        approverUserId: 7,
       });
 
       expect(result.ok).toBe(true);
@@ -262,7 +263,8 @@ describe("feishu service", () => {
       expect(fieldTexts.some((t) => t.includes("用户登录功能"))).toBe(true);
       expect(fieldTexts.some((t) => t.includes("张三"))).toBe(true);
 
-      // 验证三个按钮
+      // Batch 4-I: 三个按钮全部为 URL 按钮 (详情 + 通过 + 驳回)，
+      // 通过 / 驳回 指向 /approval/<token>。
       const actionEl = card.elements.find((el: Record<string, unknown>) => el.tag === "action");
       expect(actionEl).toBeDefined();
       expect(actionEl.actions.length).toBe(3);
@@ -271,14 +273,27 @@ describe("feishu service", () => {
         (a) => a.text.content,
       );
       expect(btnTexts.some((t) => t.includes("查看详情"))).toBe(true);
-      expect(btnTexts.some((t) => t.includes("快速通过"))).toBe(true);
+      expect(btnTexts.some((t) => t.includes("通过"))).toBe(true);
       expect(btnTexts.some((t) => t.includes("驳回"))).toBe(true);
 
-      // 验证详情链接
       const detailBtn = actionEl.actions.find((a: { text: { content: string }; url?: string }) =>
         a.text.content.includes("查看详情"),
       );
       expect(detailBtn?.url).toBe("http://localhost:5173/requirements/42");
+
+      const approveBtn = actionEl.actions.find(
+        (a: { text: { content: string }; url?: string; action_type?: string }) =>
+          a.text.content === "✅ 通过",
+      );
+      expect(approveBtn?.url).toMatch(/^http:\/\/localhost:5173\/approval\/.+/);
+      expect(approveBtn?.action_type).toBeUndefined();
+
+      const rejectBtn = actionEl.actions.find(
+        (a: { text: { content: string }; url?: string; action_type?: string }) =>
+          a.text.content === "❌ 驳回",
+      );
+      expect(rejectBtn?.url).toMatch(/^http:\/\/localhost:5173\/approval\/.+/);
+      expect(rejectBtn?.url).not.toBe(approveBtn?.url);
     });
 
     it("should return ok=false when feishu returns no message_id", async () => {
@@ -306,6 +321,7 @@ describe("feishu service", () => {
         summary: "测试摘要",
         creatorName: "李四",
         webBaseUrl: "http://localhost:5173",
+        approverUserId: 7,
       });
 
       expect(result.ok).toBe(false);

--- a/packages/gateway/src/services/feishu.ts
+++ b/packages/gateway/src/services/feishu.ts
@@ -154,9 +154,30 @@ export interface RequirementReviewCardParams {
 }
 
 export async function sendRequirementReviewCard(
-  params: RequirementReviewCardParams,
+  params: RequirementReviewCardParams & { approverUserId: number },
 ): Promise<{ ok: true; card_id: string } | { ok: false; error: string }> {
   const detailUrl = `${params.webBaseUrl}/requirements/${params.draftId}`;
+
+  // Spec §8.2 — replace interactive callbacks with Web redirect links carrying
+  // short-lived approval tokens. Feishu → Gateway reverse callbacks are no
+  // longer supported (internal network is outbound-only).
+  const { signApprovalToken } = await import("./approval-token");
+  const [approveTok, rejectTok] = await Promise.all([
+    signApprovalToken({
+      userId: params.approverUserId,
+      action: "approve",
+      resourceType: "requirement_draft",
+      resourceId: String(params.draftId),
+    }),
+    signApprovalToken({
+      userId: params.approverUserId,
+      action: "reject",
+      resourceType: "requirement_draft",
+      resourceId: String(params.draftId),
+    }),
+  ]);
+  const approveUrl = `${params.webBaseUrl}/approval/${approveTok}`;
+  const rejectUrl = `${params.webBaseUrl}/approval/${rejectTok}`;
 
   const card = {
     config: { wide_screen_mode: true },
@@ -196,17 +217,15 @@ export async function sendRequirementReviewCard(
           },
           {
             tag: "button",
-            text: { tag: "plain_text", content: "✅ 快速通过" },
+            text: { tag: "plain_text", content: "✅ 通过" },
             type: "primary",
-            action_type: "request",
-            value: JSON.stringify({ type: "requirement_approve", draft_id: params.draftId }),
+            url: approveUrl,
           },
           {
             tag: "button",
             text: { tag: "plain_text", content: "❌ 驳回" },
             type: "danger",
-            action_type: "request",
-            value: JSON.stringify({ type: "requirement_reject", draft_id: params.draftId }),
+            url: rejectUrl,
           },
         ],
       },

--- a/packages/gateway/src/services/requirement.ts
+++ b/packages/gateway/src/services/requirement.ts
@@ -330,6 +330,9 @@ export async function finalizeDraft(params: {
         summary,
         creatorName,
         webBaseUrl: config.webBaseUrl,
+        // MVP: creator is default approver. Multi-approver flow can mint
+        // per-user tokens in a follow-up.
+        approverUserId: draft.creator_id,
       });
 
       if (result.ok) {

--- a/packages/web/src/api/approval.ts
+++ b/packages/web/src/api/approval.ts
@@ -1,0 +1,72 @@
+const API_BASE = import.meta.env.VITE_API_BASE ?? "";
+
+export interface ApprovalPayload {
+  user_id: number;
+  action: "approve" | "reject";
+  resource_type: string;
+  resource_id: string;
+  jti: string;
+  iat?: number;
+  exp?: number;
+}
+
+export type ApprovalVerifyResult =
+  | { ok: true; payload: ApprovalPayload }
+  | { ok: false; code: string; error: string; status: number };
+
+/** Verify a token (does NOT consume it). Safe to call on page load. */
+export async function verifyApproval(token: string): Promise<ApprovalVerifyResult> {
+  const res = await fetch(`${API_BASE}/api/approval/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ token }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok && body.ok) {
+    return { ok: true, payload: body.payload as ApprovalPayload };
+  }
+  return {
+    ok: false,
+    code: body.code ?? "unknown",
+    error: body.error ?? `HTTP ${res.status}`,
+    status: res.status,
+  };
+}
+
+export type ApprovalExecuteResult =
+  | {
+      ok: true;
+      action: "approve" | "reject";
+      resource: { type: string; id: string };
+    }
+  | { ok: false; code: string; error: string; status: number };
+
+/** Atomically verify + consume + apply the action. Requires user JWT. */
+export async function executeApproval(
+  token: string,
+  userToken: string,
+  note?: string,
+): Promise<ApprovalExecuteResult> {
+  const res = await fetch(`${API_BASE}/api/approval/execute`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${userToken}`,
+    },
+    body: JSON.stringify({ token, note }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (res.ok && body.ok) {
+    return {
+      ok: true,
+      action: body.action,
+      resource: body.resource,
+    };
+  }
+  return {
+    ok: false,
+    code: body.code ?? "unknown",
+    error: body.error ?? `HTTP ${res.status}`,
+    status: res.status,
+  };
+}

--- a/packages/web/src/pages/ApprovalConfirm.vue
+++ b/packages/web/src/pages/ApprovalConfirm.vue
@@ -1,0 +1,184 @@
+<template>
+  <div
+    class="min-h-screen flex items-center justify-center px-4"
+    style="background-color: var(--color-bg-primary)"
+  >
+    <div
+      class="w-full max-w-md rounded-lg border p-6"
+      style="background-color: var(--color-bg-secondary); border-color: var(--color-border-primary)"
+    >
+      <h1 class="text-lg font-semibold mb-4" style="color: var(--color-text-primary)">
+        需求草稿审批
+      </h1>
+
+      <div v-if="phase === 'loading'" class="text-sm" style="color: var(--color-text-tertiary)">
+        正在验证审批链接...
+      </div>
+
+      <div v-else-if="phase === 'invalid'" class="space-y-3">
+        <p class="text-sm" style="color: var(--color-error-light)">
+          {{ invalidMessage }}
+        </p>
+        <button
+          class="text-xs underline"
+          style="color: var(--color-text-tertiary)"
+          @click="goDashboard"
+        >
+          返回首页
+        </button>
+      </div>
+
+      <div v-else-if="phase === 'confirm' && payload" class="space-y-4">
+        <div class="text-sm space-y-1" style="color: var(--color-text-secondary)">
+          <p>
+            即将对
+            <span style="color: var(--color-text-primary)">
+              {{ resourceLabel(payload.resource_type) }} #{{ payload.resource_id }}
+            </span>
+            执行
+            <span :class="payload.action === 'approve' ? 'text-green-600' : 'text-red-600'">
+              {{ payload.action === "approve" ? "通过" : "驳回" }}
+            </span>
+            操作。
+          </p>
+          <p class="text-xs" style="color: var(--color-text-tertiary)">
+            此链接 15 分钟内有效，且只能使用一次。
+          </p>
+        </div>
+
+        <textarea
+          v-model="note"
+          rows="3"
+          placeholder="可选：补充一句说明（会记录在审批日志里）"
+          class="w-full rounded-md border px-3 py-2 text-sm"
+          style="
+            background-color: var(--color-bg-primary);
+            border-color: var(--color-border-primary);
+            color: var(--color-text-primary);
+          "
+        />
+
+        <div class="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm border"
+            style="border-color: var(--color-border-primary); color: var(--color-text-secondary)"
+            :disabled="submitting"
+            @click="goDashboard"
+          >
+            取消
+          </button>
+          <button
+            type="button"
+            class="rounded-md px-3 py-1.5 text-sm text-white"
+            :style="{
+              backgroundColor: payload.action === 'approve' ? 'rgb(22 163 74)' : 'rgb(220 38 38)',
+              opacity: submitting ? 0.6 : 1,
+            }"
+            :disabled="submitting"
+            @click="confirm"
+          >
+            {{ submitting ? "提交中..." : payload.action === "approve" ? "确认通过" : "确认驳回" }}
+          </button>
+        </div>
+      </div>
+
+      <div v-else-if="phase === 'done'" class="space-y-3">
+        <p class="text-sm" style="color: var(--color-text-primary)">✅ 已完成：{{ doneLabel }}</p>
+        <button
+          class="text-xs underline"
+          style="color: var(--color-text-tertiary)"
+          @click="goDashboard"
+        >
+          返回首页
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from "vue";
+import { useRoute, useRouter } from "vue-router";
+import { useAuthStore } from "../stores/auth";
+import { executeApproval, verifyApproval, type ApprovalPayload } from "../api/approval";
+
+const route = useRoute();
+const router = useRouter();
+const auth = useAuthStore();
+
+type Phase = "loading" | "invalid" | "confirm" | "done";
+const phase = ref<Phase>("loading");
+const payload = ref<ApprovalPayload | null>(null);
+const invalidMessage = ref("");
+const note = ref("");
+const submitting = ref(false);
+const doneLabel = ref("");
+
+const token = computed(() => (route.params.token as string) ?? "");
+
+function resourceLabel(type: string): string {
+  if (type === "requirement_draft") return "需求草稿";
+  return type;
+}
+
+function mapErrorCode(code: string, fallback: string): string {
+  switch (code) {
+    case "expired":
+      return "审批链接已过期（超过 15 分钟）。请回到需求详情页重新发起审批。";
+    case "already_consumed":
+      return "该审批链接已被使用过，不能重复操作。";
+    case "user_mismatch":
+      return "当前登录账号与审批链接指向的用户不一致，请换号后重试。";
+    case "malformed":
+    case "invalid":
+      return "审批链接无效或损坏。";
+    default:
+      return fallback;
+  }
+}
+
+function goDashboard(): void {
+  router.replace("/dashboard");
+}
+
+async function confirm(): Promise<void> {
+  if (!token.value || !auth.token) return;
+  submitting.value = true;
+  const result = await executeApproval(token.value, auth.token, note.value || undefined);
+  submitting.value = false;
+  if (!result.ok) {
+    phase.value = "invalid";
+    invalidMessage.value = mapErrorCode(result.code, result.error);
+    return;
+  }
+  doneLabel.value = `${resourceLabel(result.resource.type)} #${result.resource.id} 已${
+    result.action === "approve" ? "通过" : "驳回"
+  }。`;
+  phase.value = "done";
+}
+
+onMounted(async () => {
+  if (!token.value) {
+    invalidMessage.value = "缺少审批 token。";
+    phase.value = "invalid";
+    return;
+  }
+  if (!auth.token) {
+    // Not logged in — bounce to login, round-trip back after auth.
+    router.replace({
+      name: "login",
+      query: { redirect: route.fullPath },
+    });
+    return;
+  }
+  const result = await verifyApproval(token.value);
+  if (!result.ok) {
+    invalidMessage.value = mapErrorCode(result.code, result.error);
+    phase.value = "invalid";
+    return;
+  }
+  payload.value = result.payload;
+  phase.value = "confirm";
+});
+</script>

--- a/packages/web/src/router/index.ts
+++ b/packages/web/src/router/index.ts
@@ -74,6 +74,14 @@ const router = createRouter({
       component: () => import("../pages/Profile.vue"),
     },
     {
+      // Public route — page handles redirect-to-login itself so the user
+      // lands on a clear "please sign in" flow rather than a raw bounce.
+      path: "/approval/:token",
+      name: "approval",
+      component: () => import("../pages/ApprovalConfirm.vue"),
+      meta: { public: true },
+    },
+    {
       path: "/:pathMatch(.*)*",
       name: "NotFound",
       component: () => import("../pages/NotFound.vue"),


### PR DESCRIPTION
## Summary
Batch 4-I — 把飞书卡片按钮从反向回调改成 Web 跳转 + 15min 一次性 JWT（spec §8）。

**Gateway**:
- `sendRequirementReviewCard` 加 `approverUserId`，为 approve/reject 各签一条 token，按钮改为 URL 按钮指向 `${webBaseUrl}/approval/<token>`
- `finalizeDraft` 传 `draft.creator_id` 做默认 approver
- `routes/webhook.ts` 删掉飞书卡片回调处理（保留 URL verification challenge）
- 删掉 6 个飞书回调测试 + 新增一个 "忽略 legacy callback" 测试

**Web**:
- `/approval/:token` 确认页：未登录跳 `/login` (带 redirect)，已登录 → /verify → 显示资源/动作 → 确认 → /execute
- 错误码映射中文提示：过期 / 已消费 / 用户不匹配 / 无效
- `api/approval.ts` 封装两个 endpoint

## Test plan
- [x] Gateway 294 tests passing (删除过时回调测试)
- [x] Web lint + test 全绿
- [ ] E2E: finalize → 飞书卡片点链接 → /approval/:token 确认 → draft 状态流转

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)