### PR TITLE
feat: NanoClaw 鉴权透传 Phase 0 (Gateway + Web)

### DIFF
--- a/docs/superpowers/plans/2026-04-14-nanoclaw-auth-passthrough.md
+++ b/docs/superpowers/plans/2026-04-14-nanoclaw-auth-passthrough.md
@@ -1,0 +1,658 @@
+# NanoClaw 鉴权透传 Implementation Plan（v2 修订）
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans.
+
+**Goal:** Web AiChat → NanoClaw Web channel → 容器内 skill → Gateway 全链路带真实用户身份。
+
+**Architecture:** Web 持 `arcflow_token` (JWT)。POST /api/chat 用 Authorization header，SSE 用 ?token= query。NanoClaw 首次见到 client_id 调 Gateway `/auth/verify` 缓存 ClientAuthStore。container-runner 为每个容器挂载 0400 权限的凭证文件 `/run/arcflow/credentials.json`，容器退出即清理。Skill 读文件直调 Gateway。
+
+**Tech Stack:** Bun + Hono（Gateway，已完成）· Node + Express（NanoClaw）· Docker CLI · Vue 3 + Pinia（Web）
+
+**Spec:** `docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md` (v2)
+
+---
+
+## 进度
+
+| Task | 状态 | Commit |
+|---|---|---|
+| 1. Gateway `resolveUserContext` | ✅ | `476d27f` |
+| 2. Gateway `POST /auth/verify` | ✅ | `c39c0b1` |
+| 3. NanoClaw `ClientAuthStore` + gateway verify helper | ⏳ | |
+| 4. NanoClaw Web channel POST 鉴权 | ⏳ | |
+| 5. NanoClaw Web channel SSE 鉴权（?token=） | ⏳ | |
+| 6. container-runner 凭证文件挂载 | ⏳ | |
+| 7. 容器内 skill 占位 + 联通验证 | ⏳ | |
+| 8. Web POST 带 Authorization header | ⏳ | |
+| 9. Web SSE ?token= + AUTH_EXPIRED refresh 重连 | ⏳ | |
+| 10. 端到端手测 + 验收勾选 + PR | ⏳ | |
+
+---
+
+## 文件结构
+
+**NanoClaw 仓**（`~/code/nanoclaw/`）：
+
+| 文件 | 动作 |
+|---|---|
+| `src/auth/client-auth-store.ts` | Create — 内存 ClientAuthStore |
+| `src/auth/client-auth-store.test.ts` | Create |
+| `src/auth/gateway-verify.ts` | Create — 调用 Gateway `/auth/verify` 的 helper |
+| `src/auth/gateway-verify.test.ts` | Create |
+| `src/channels/web.ts` | Modify — POST/SSE 鉴权 |
+| `src/channels/web.test.ts` | Modify |
+| `src/container-runner.ts` | Modify — 挂载凭证文件 |
+| `src/container-runner.test.ts` | Modify |
+| `src/auth/credentials-file.ts` | Create — 写 / 清理凭证文件 |
+| `src/auth/credentials-file.test.ts` | Create |
+
+**ArcFlow 仓**（本仓 `packages/web/`）：
+
+| 文件 | 动作 |
+|---|---|
+| `packages/web/src/api/nanoclaw.ts` | Modify — POST 带 Authorization + SSE 带 ?token= |
+| `packages/web/src/composables/useAiChat.ts` | Modify — AUTH_EXPIRED 触发 refresh + 重连 |
+| `packages/web/src/api/nanoclaw.test.ts` | Create |
+
+---
+
+## Task 3: NanoClaw `ClientAuthStore` + Gateway verify helper
+
+**Files:**
+
+- Create: `~/code/nanoclaw/src/auth/client-auth-store.ts`
+- Create: `~/code/nanoclaw/src/auth/client-auth-store.test.ts`
+- Create: `~/code/nanoclaw/src/auth/gateway-verify.ts`
+- Create: `~/code/nanoclaw/src/auth/gateway-verify.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+`client-auth-store.test.ts`:
+
+```ts
+import { ClientAuthStore } from './client-auth-store.js';
+
+describe('ClientAuthStore', () => {
+  it('set + get roundtrip', () => {
+    const s = new ClientAuthStore();
+    s.set('c-1', { userId: 7, workspaceId: 3, displayName: 'U', token: 't', expiresAt: 9e9 });
+    expect(s.get('c-1')?.userId).toBe(7);
+  });
+  it('isExpired true when past expiresAt', () => {
+    const s = new ClientAuthStore();
+    s.set('c-1', { userId: 1, workspaceId: 1, displayName: '', token: '', expiresAt: 1 });
+    expect(s.isExpired('c-1')).toBe(true);
+  });
+  it('delete removes entry', () => {
+    const s = new ClientAuthStore();
+    s.set('c-1', { userId: 1, workspaceId: 1, displayName: '', token: '', expiresAt: 9e9 });
+    s.delete('c-1');
+    expect(s.get('c-1')).toBeUndefined();
+  });
+});
+```
+
+`gateway-verify.test.ts`:
+
+```ts
+import { verifyViaGateway } from './gateway-verify.js';
+
+describe('verifyViaGateway', () => {
+  const origFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = origFetch; });
+
+  it('returns data on 200', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      code: 0, data: { userId: 7, workspaceId: 3, displayName: 'U', expiresAt: 9e9 },
+    }), { status: 200 })) as any;
+    const r = await verifyViaGateway('http://g', 't');
+    expect(r.userId).toBe(7);
+  });
+
+  it('throws AUTH_EXPIRED on 401 with code AUTH_EXPIRED', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      code: 'AUTH_EXPIRED',
+    }), { status: 401 })) as any;
+    await expect(verifyViaGateway('http://g', 't')).rejects.toThrow('AUTH_EXPIRED');
+  });
+
+  it('throws AUTH_INVALID on other 401', async () => {
+    globalThis.fetch = (async () => new Response(JSON.stringify({
+      code: 'AUTH_INVALID',
+    }), { status: 401 })) as any;
+    await expect(verifyViaGateway('http://g', 't')).rejects.toThrow('AUTH_INVALID');
+  });
+
+  it('throws GATEWAY_UNREACHABLE on network error', async () => {
+    globalThis.fetch = (async () => { throw new Error('ECONNREFUSED'); }) as any;
+    await expect(verifyViaGateway('http://g', 't')).rejects.toThrow('GATEWAY_UNREACHABLE');
+  });
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+`cd ~/code/nanoclaw && npm test -- client-auth-store gateway-verify`
+
+- [ ] **Step 3: Implement**
+
+`client-auth-store.ts`:
+
+```ts
+export interface ClientAuth {
+  userId: number;
+  workspaceId: number;
+  displayName: string;
+  token: string;
+  expiresAt: number;
+}
+
+export class ClientAuthStore {
+  private map = new Map<string, ClientAuth>();
+  set(clientId: string, a: ClientAuth) { this.map.set(clientId, a); }
+  get(clientId: string) { return this.map.get(clientId); }
+  delete(clientId: string) { this.map.delete(clientId); }
+  isExpired(clientId: string) {
+    const a = this.map.get(clientId);
+    return !a || a.expiresAt * 1000 < Date.now();
+  }
+}
+```
+
+`gateway-verify.ts`:
+
+```ts
+export interface VerifiedContext {
+  userId: number;
+  workspaceId: number;
+  displayName: string;
+  expiresAt: number;
+}
+
+export async function verifyViaGateway(
+  gatewayUrl: string,
+  token: string,
+): Promise<VerifiedContext> {
+  let res: Response;
+  try {
+    res = await fetch(`${gatewayUrl}/auth/verify`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch {
+    throw new Error('GATEWAY_UNREACHABLE');
+  }
+  const json: any = await res.json().catch(() => ({}));
+  if (res.status === 200 && json.code === 0) return json.data;
+  if (res.status === 401 && json.code === 'AUTH_EXPIRED') throw new Error('AUTH_EXPIRED');
+  throw new Error('AUTH_INVALID');
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+`cd ~/code/nanoclaw && npm test -- client-auth-store gateway-verify`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd ~/code/nanoclaw
+git checkout -b feat/arcflow-auth-passthrough
+git add src/auth/
+git commit -m "feat: ClientAuthStore + gateway /auth/verify helper"
+```
+
+---
+
+## Task 4: NanoClaw Web channel — POST 鉴权
+
+**Files:**
+
+- Modify: `~/code/nanoclaw/src/channels/web.ts`
+- Modify: `~/code/nanoclaw/src/channels/web.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+在 `web.test.ts` 追加：
+
+```ts
+it('POST /api/chat without Authorization returns 401 AUTH_INVALID', async () => {
+  const res = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ client_id: 'c-1', message: 'hi' }),
+  });
+  expect(res.status).toBe(401);
+  expect((await res.json()).code).toBe('AUTH_INVALID');
+});
+
+it('POST /api/chat with valid bearer populates store + invokes onMessage', async () => {
+  // mock verifyViaGateway 返回 {userId:7, workspaceId:3, …}
+  const res = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      authorization: 'Bearer t.ok',
+    },
+    body: JSON.stringify({ client_id: 'c-2', message: 'hi' }),
+  });
+  expect(res.status).toBe(200);
+  expect(onMessageSpy).toHaveBeenCalled();
+  expect(store.get('c-2')?.userId).toBe(7);
+});
+
+it('POST /api/chat with expired bearer returns 401 AUTH_EXPIRED', async () => {
+  // mock verifyViaGateway throw AUTH_EXPIRED
+  const res = await fetch(`${baseUrl}/api/chat`, {
+    method: 'POST',
+    headers: { authorization: 'Bearer t.exp', 'content-type': 'application/json' },
+    body: JSON.stringify({ client_id: 'c-3', message: 'hi' }),
+  });
+  expect(res.status).toBe(401);
+  expect((await res.json()).code).toBe('AUTH_EXPIRED');
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+- [ ] **Step 3: Implement**
+
+在 `web.ts` 构造函数中接受 `store: ClientAuthStore` 和 `verify: (token) => Promise<VerifiedContext>` 依赖注入（便于测试）。`POST /api/chat` handler 改造：
+
+```ts
+app.post('/api/chat', async (req, res) => {
+  const header = req.header('authorization');
+  if (!header?.startsWith('Bearer ')) {
+    return res.status(401).json({ ok: false, code: 'AUTH_INVALID' });
+  }
+  const token = header.slice(7);
+  let ctx = this.store.get(req.body.client_id);
+  if (!ctx || ctx.token !== token || this.store.isExpired(req.body.client_id)) {
+    try {
+      const v = await this.verify(token);
+      ctx = { ...v, token };
+      this.store.set(req.body.client_id, ctx);
+    } catch (e: any) {
+      const code = e.message === 'AUTH_EXPIRED' ? 'AUTH_EXPIRED' : 'AUTH_INVALID';
+      return res.status(401).json({ ok: false, code });
+    }
+  }
+  // 现有 onMessage 分发保持不变，但 chatJid 带上 workspace 信息（或走 ctx 传递）
+  // … (existing logic)
+});
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit** `feat(web-channel): require Authorization on POST /api/chat`
+
+---
+
+## Task 5: NanoClaw Web channel — SSE 鉴权
+
+**Files:** `src/channels/web.ts`, `src/channels/web.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+it('GET /api/chat/sse without token returns 401', async () => {
+  const res = await fetch(`${baseUrl}/api/chat/sse?client_id=c-1`);
+  expect(res.status).toBe(401);
+});
+
+it('GET /api/chat/sse with valid token establishes SSE', async () => {
+  store.set('c-2', { userId:7, workspaceId:3, displayName:'U', token:'t.ok', expiresAt: 9e9 });
+  const res = await fetch(`${baseUrl}/api/chat/sse?client_id=c-2&token=t.ok`);
+  expect(res.status).toBe(200);
+  expect(res.headers.get('content-type')).toContain('text/event-stream');
+});
+
+it('GET /api/chat/sse with mismatched token returns 401', async () => {
+  store.set('c-3', { userId:7, workspaceId:3, displayName:'U', token:'t.ok', expiresAt: 9e9 });
+  const res = await fetch(`${baseUrl}/api/chat/sse?client_id=c-3&token=evil`);
+  expect(res.status).toBe(401);
+});
+```
+
+- [ ] **Step 2: Run — expect fail**
+
+- [ ] **Step 3: Implement**
+
+```ts
+app.get('/api/chat/sse', async (req, res) => {
+  const clientId = req.query.client_id as string;
+  const token = req.query.token as string;
+  if (!clientId || !token) {
+    return res.status(401).json({ ok: false, code: 'AUTH_INVALID' });
+  }
+  let ctx = this.store.get(clientId);
+  if (!ctx || ctx.token !== token || this.store.isExpired(clientId)) {
+    try {
+      const v = await this.verify(token);
+      ctx = { ...v, token };
+      this.store.set(clientId, ctx);
+    } catch (e: any) {
+      const code = e.message === 'AUTH_EXPIRED' ? 'AUTH_EXPIRED' : 'AUTH_INVALID';
+      return res.status(401).json({ ok: false, code });
+    }
+  }
+  // existing SSE setup …
+});
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit** `feat(web-channel): require token on SSE subscription`
+
+---
+
+## Task 6: container-runner 凭证文件挂载
+
+**Files:**
+
+- Create: `~/code/nanoclaw/src/auth/credentials-file.ts`
+- Create: `~/code/nanoclaw/src/auth/credentials-file.test.ts`
+- Modify: `~/code/nanoclaw/src/container-runner.ts`
+- Modify: `~/code/nanoclaw/src/container-runner.test.ts`
+
+- [ ] **Step 1: Write failing tests for credentials file**
+
+`credentials-file.test.ts`:
+
+```ts
+import fs from 'node:fs/promises';
+import { writeCredentialsFile, cleanupCredentialsFile } from './credentials-file.js';
+
+describe('credentials-file', () => {
+  it('writes JSON with mode 0400 and returns path', async () => {
+    const path = await writeCredentialsFile({
+      token: 'jwt.xxx', userId: 7, workspaceId: 3,
+      gatewayUrl: 'http://g', displayName: 'U',
+    });
+    const stat = await fs.stat(path);
+    expect(stat.mode & 0o777).toBe(0o400);
+    const body = JSON.parse(await fs.readFile(path, 'utf8'));
+    expect(body.token).toBe('jwt.xxx');
+    await cleanupCredentialsFile(path);
+  });
+
+  it('cleanup removes the file', async () => {
+    const path = await writeCredentialsFile({
+      token: 't', userId: 1, workspaceId: 1, gatewayUrl: 'http://g', displayName: '',
+    });
+    await cleanupCredentialsFile(path);
+    await expect(fs.stat(path)).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Implement `credentials-file.ts`**
+
+```ts
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+export interface Credentials {
+  token: string;
+  userId: number;
+  workspaceId: number;
+  gatewayUrl: string;
+  displayName: string;
+}
+
+export async function writeCredentialsFile(c: Credentials): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'arcflow-creds-'));
+  const filePath = path.join(dir, 'credentials.json');
+  await fs.writeFile(filePath, JSON.stringify(c), { mode: 0o400 });
+  return filePath;
+}
+
+export async function cleanupCredentialsFile(filePath: string): Promise<void> {
+  try {
+    await fs.unlink(filePath);
+    await fs.rmdir(path.dirname(filePath));
+  } catch { /* best effort */ }
+}
+```
+
+- [ ] **Step 3: Run — expect pass for credentials-file**
+
+- [ ] **Step 4: Wire into container-runner**
+
+在 container-runner 启动容器入口（找现有的 `docker run ...` 构造处），接受 `ClientAuth` 参数：
+
+```ts
+// 伪代码（根据实际 container-runner.ts 结构适配）
+async function startContainer(chatJid, auth: ClientAuth) {
+  const credPath = await writeCredentialsFile({
+    token: auth.token,
+    userId: auth.userId,
+    workspaceId: auth.workspaceId,
+    displayName: auth.displayName,
+    gatewayUrl: process.env.ARCFLOW_GATEWAY_URL!,
+  });
+  dockerArgs.push('-v', `${credPath}:/run/arcflow/credentials.json:ro`);
+  const proc = spawn('docker', dockerArgs, ...);
+  proc.once('exit', () => { void cleanupCredentialsFile(credPath); });
+  return proc;
+}
+```
+
+调用链：web.ts POST handler 从 store 取到 auth → 传给 index.ts onMessage → 传给 container-runner（需要沿途加参数）。
+
+- [ ] **Step 5: Run — expect pass + smoke**
+
+本地测试：修改 container-runner 使其打印启动 docker args，跑一次确认 `-v /tmp/arcflow-creds-…/credentials.json:/run/arcflow/credentials.json:ro` 出现。
+
+- [ ] **Step 6: Commit** `feat(container-runner): mount arcflow credentials into container`
+
+---
+
+## Task 7: 容器内 skill 占位 + 联通验证
+
+**Files:**
+
+- Create: `~/code/nanoclaw/skills/arcflow-auth-check/SKILL.md`
+
+- [ ] **Step 1: 写 skill 最小验证脚本**
+
+在 `~/code/nanoclaw/skills/arcflow-auth-check/SKILL.md` 里写 frontmatter（`name: arcflow-auth-check`, `description: Phase 0 联通验证`），正文只放一个 shell 片段：
+
+```bash
+#!/bin/bash
+set -e
+TOKEN=$(jq -r .token /run/arcflow/credentials.json)
+GATEWAY=$(jq -r .gatewayUrl /run/arcflow/credentials.json)
+curl -fsS -H "Authorization: Bearer $TOKEN" "$GATEWAY/api/auth/me"
+```
+
+- [ ] **Step 2: 本地端到端**
+
+- 启动 Gateway（本仓）：`cd packages/gateway && bun run dev`
+- 启动 NanoClaw（web channel only）：`cd ~/code/nanoclaw && npm run dev`
+- 用 curl 模拟 Web 请求：
+
+```bash
+TOKEN=$(通过 Gateway OAuth flow 拿一个真 token)
+curl -X POST http://localhost:3002/api/chat \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "content-type: application/json" \
+  -d '{"client_id":"test-1","message":"/arcflow-auth-check"}'
+```
+
+- 确认容器内 skill 能打印出当前用户 JSON。
+
+- [ ] **Step 3: Commit** `feat(skills): arcflow-auth-check Phase 0 smoke skill`
+
+---
+
+## Task 8: Web — POST 带 Authorization header
+
+**Files:**
+
+- Modify: `packages/web/src/api/nanoclaw.ts`
+
+- [ ] **Step 1: Locate current POST**
+
+```bash
+grep -n "api/chat" packages/web/src/api/nanoclaw.ts
+```
+
+- [ ] **Step 2: Inject token**
+
+```ts
+import { useAuthStore } from '@/stores/auth';
+
+export async function postChatMessage(clientId: string, message: string) {
+  const token = useAuthStore().token;
+  if (!token) throw new Error('NO_AUTH');
+  const res = await fetch(`${import.meta.env.VITE_NANOCLAW_URL}/api/chat`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ client_id: clientId, message }),
+  });
+  if (res.status === 401) {
+    const body = await res.json().catch(() => ({}));
+    throw Object.assign(new Error(body.code || 'AUTH_INVALID'), { code: body.code });
+  }
+  return res.json();
+}
+```
+
+- [ ] **Step 3: Commit** `feat(web): attach arcflow_token to /api/chat POST`
+
+---
+
+## Task 9: Web — SSE ?token= + AUTH_EXPIRED 重连
+
+**Files:**
+
+- Modify: `packages/web/src/api/nanoclaw.ts`
+- Modify: `packages/web/src/composables/useAiChat.ts`
+- Create: `packages/web/src/api/nanoclaw.test.ts`
+
+- [ ] **Step 1: Write failing test**
+
+```ts
+import { vi, describe, it, expect } from 'vitest';
+import { createSseAuthHandler } from './useAiChat';
+
+describe('SSE auth handling', () => {
+  it('on AUTH_EXPIRED calls refresh + reconnect', async () => {
+    const refresh = vi.fn().mockResolvedValue('new.token');
+    const reconnect = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect });
+    await h({ type: 'error', code: 'AUTH_EXPIRED' });
+    expect(refresh).toHaveBeenCalled();
+    expect(reconnect).toHaveBeenCalled();
+  });
+
+  it('on refresh failure redirects to login', async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error('x'));
+    const redirect = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect: () => {}, redirect });
+    await h({ type: 'error', code: 'AUTH_EXPIRED' });
+    expect(redirect).toHaveBeenCalledWith('/login');
+  });
+});
+```
+
+- [ ] **Step 2: Implement**
+
+`nanoclaw.ts`:
+
+```ts
+export function connectSse(clientId: string): EventSource {
+  const token = useAuthStore().token;
+  if (!token) throw new Error('NO_AUTH');
+  const url = new URL(`${import.meta.env.VITE_NANOCLAW_URL}/api/chat/sse`);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('token', token);
+  return new EventSource(url.toString());
+}
+```
+
+`useAiChat.ts`:
+
+```ts
+export function createSseAuthHandler(deps: {
+  refresh: () => Promise<string>;
+  reconnect: () => void;
+  redirect?: (p: string) => void;
+}) {
+  return async (msg: { type: string; code?: string }) => {
+    if (msg.type === 'error' && msg.code === 'AUTH_EXPIRED') {
+      try {
+        await deps.refresh();
+        deps.reconnect();
+      } catch {
+        deps.redirect?.('/login');
+      }
+    }
+  };
+}
+```
+
+在 SSE `onmessage` 里解析并调用 handler。
+
+- [ ] **Step 3: Run — expect pass**
+
+`cd packages/web && npm test -- nanoclaw`
+
+- [ ] **Step 4: Commit** `feat(web): SSE token query + AUTH_EXPIRED refresh`
+
+---
+
+## Task 10: 端到端手测 + PR
+
+- [ ] **Step 1: 启服务**
+
+```bash
+# T1: Gateway
+cd packages/gateway && bun run dev   # :3001
+
+# T2: NanoClaw
+cd ~/code/nanoclaw && ARCFLOW_GATEWAY_URL=http://host.docker.internal:3001 npm run dev
+
+# T3: Web
+cd packages/web && npm run dev
+```
+
+- [ ] **Step 2: 跑 6 条路径**
+
+1. 登录 → AiChat 发 `/arcflow-auth-check` → 容器内 curl Gateway 成功，SSE 回流用户 JSON。
+2. 清空 `arcflow_token` → AiChat POST → 401 `AUTH_INVALID`。
+3. 手工构造过期 JWT 塞进 localStorage → AiChat POST → 401 `AUTH_EXPIRED` → Web 自动 refresh → 重发成功。
+4. SSE 连接中途 token 过期 → 推 error event → Web refresh + 重连。
+5. 容器启动后 `ls -l /run/arcflow/credentials.json` 显示 0400 readonly。
+6. 容器退出后 host 上 `/tmp/arcflow-creds-*` 目录被清理。
+
+- [ ] **Step 3: 更新 spec 验收勾选**
+
+编辑 `docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md` §8，把 6 条勾上，commit `docs: mark Phase 0 acceptance complete`。
+
+- [ ] **Step 4: 两个仓分别开 PR**
+
+```bash
+# ArcFlow 本仓
+git push -u origin feat/nanoclaw-auth-passthrough
+gh pr create --title "feat: NanoClaw 鉴权透传 Phase 0 (Gateway + Web)" …
+
+# nanoclaw fork
+cd ~/code/nanoclaw && git push -u origin feat/arcflow-auth-passthrough
+gh pr create --repo ssyamv/nanoclaw --title "feat: ArcFlow auth passthrough (Phase 0)" …
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec 覆盖**：Spec §3.2 → Task 4/5；§3.3 → Task 6；§3.4 → Task 7；§3.5 → Task 8/9；§5 错误路径 → 每 Task 含负路径测试；§6 测试策略 → Task 3/4/5/6/9 单测 + Task 10 端到端。
+- **类型一致**：`ClientAuth.workspaceId` 全程 `number`（Gateway 侧 `/auth/verify` 返 number）；`Credentials` 类型在 Task 6/7 一致。
+- **错误码**：`NO_AUTH` / `AUTH_INVALID` / `AUTH_EXPIRED` / `GATEWAY_UNREACHABLE` 贯穿。
+- **已作废内容**：v1 plan 的 SessionStore（WS conn 绑定）/ handshake / subprotocol / skill-runtime GatewayClient 全部弃用，由 ClientAuthStore（client_id 绑定）/ HTTP header+SSE query / credentials file mount 替代。

--- a/docs/superpowers/specs/2026-04-14-arcflow-api-skill-design.md
+++ b/docs/superpowers/specs/2026-04-14-arcflow-api-skill-design.md
@@ -1,0 +1,187 @@
+# arcflow-api Skill 设计（Phase 1–3）
+
+> 日期：2026-04-14
+> 分支建议：`feat/arcflow-api-skill`
+> 关联 Epic：NanoClaw 作为 ArcFlow 核心入口（#85–#94）
+> 前置依赖：`2026-04-14-nanoclaw-auth-passthrough-design.md`（Phase 0）
+
+## 1. 背景与目标
+
+目标：给 NanoClaw 装上"手脚"。当前 NanoClaw fork 只带 31 个通用 skill，无法代表 ArcFlow 执行真实业务。本 spec 规划一个专用 skill 包 `arcflow-api`，分三期交付，最终让 Web AiChat 成为用户的统一入口：
+
+- 查我的 issue / PRD / 近期活动（只读）
+- 创建需求草稿、触发 PRD 生成、更新 issue 状态（写入）
+- 结果以消息卡片呈现，支持状态追踪与跳转
+
+## 2. Skill 定位
+
+`arcflow-api` 是 NanoClaw skill 包，位于 `packages/nanoclaw-skills/arcflow-api/`（本地开发仓内），编译产物部署到服务器 NanoClaw fork。Skill 本身是纯 TS 模块，通过 HTTP 调 Gateway（胶水服务）完成所有操作，**不直接访问数据库、Git、Plane、Dify**。
+
+所有调用均从 session 读 `token` 透传给 Gateway（Phase 0 约定）。
+
+## 3. Phase 1 — 只读 MVP（~3-5 天）
+
+### 3.1 工具清单
+
+| 工具 | 说明 | 调用 Gateway 端点 |
+|---|---|---|
+| `list_my_issues` | 列出当前用户在当前 workspace 下的 issue | `GET /api/issues?assignee=self` |
+| `read_prd` | 按 ID 或路径读取 PRD 全文 | `GET /api/docs/prd/:id` |
+| `search_docs` | 跨 PRD/技术设计/API 规范全文检索 | `GET /api/docs/search?q=` |
+| `get_workspace_info` | 当前 workspace 元信息（成员、项目、最近活动计数） | `GET /api/workspaces/:id` |
+| `list_recent_activity` | 最近 N 条活动（PR 合并、PRD 更新、Issue 状态变更） | `GET /api/activity?limit=20` |
+
+### 3.2 工具接口约定
+
+每个工具遵循统一签名：
+
+```ts
+interface SkillTool<Input, Output> {
+  name: string;
+  description: string;      // 供 LLM 理解何时调用
+  inputSchema: JSONSchema;
+  execute(input: Input, ctx: SkillContext): Promise<Output>;
+}
+
+interface SkillContext {
+  session: NanoClawSession;  // 含 token / userId / workspaceId
+  gateway: GatewayClient;    // 已注入 token 透传的 HTTP client
+  logger: Logger;
+}
+```
+
+### 3.3 输出格式
+
+只读工具返回结构化 JSON，NanoClaw Agent SDK 按需格式化为自然语言。关键字段必须包含：
+
+- `items`：数据列表
+- `cursor`：分页游标（若适用）
+- `links`：跳转链接数组（如 Plane issue URL、ArcFlow 文档路径），供 Phase 3 卡片化使用
+
+### 3.4 验收标准
+
+1. 5 个工具各自单测覆盖成功 / 空结果 / Gateway 错误三种 case。
+2. 本地跑通：`mock Gateway` 场景下 skill 输入输出符合 schema。
+3. 服务器部署后，Web AiChat 说"看看我最近的 PRD"能返回真实列表。
+
+## 4. Phase 2 — 写能力（~3-5 天）
+
+### 4.1 工具清单
+
+| 工具 | 说明 | 调用 Gateway 端点 |
+|---|---|---|
+| `create_requirement_draft` | 基于自然语言描述创建需求草稿 | `POST /api/requirements/drafts` |
+| `trigger_prd_generation` | 对指定草稿触发 Dify PRD 生成工作流 | `POST /api/prd/generate` |
+| `update_issue_status` | 改 issue 状态（Backlog/InProgress/Review/Done） | `PATCH /api/issues/:id` |
+
+### 4.2 安全约束
+
+写操作触发 Stage D 原子写入（docs Git + Plane Issue），必须满足：
+
+1. **幂等键**：每次调用带 `idempotencyKey`（UUID），Gateway 侧去重。
+2. **dry-run 预览**：所有写工具支持 `dryRun: true`，返回"将要做什么"不实际执行。LLM 在用户明确确认前默认 `dryRun`。
+3. **回显审批链接**：写操作成功后返回 Plane issue URL + 飞书审批卡片状态，供用户立刻核对。
+4. **失败不重试**：Gateway 返非 2xx 一律直接抛给用户，不自动重试（避免重复创建）。
+
+### 4.3 验收标准
+
+1. 三个写工具单测覆盖 dryRun / 成功 / 幂等冲突 / Gateway 错误。
+2. 端到端：Web AiChat 说"帮我创建个需求草稿：XXX" → 确认 → Plane 出现 issue + docs 仓出现草稿文件。
+3. 重复提交同一 idempotencyKey 不产生第二条记录。
+
+## 5. Phase 3 — 交互闭环（~2-3 天）
+
+### 5.1 消息卡片化
+
+NanoClaw 回流 Web 的消息支持富内容类型：
+
+```ts
+type RichMessage =
+  | { type: 'text'; content: string }
+  | { type: 'card'; title: string; fields: KV[]; actions: Action[] }
+  | { type: 'status'; stage: string; progress: number; detail?: string };
+
+interface Action {
+  label: string;   // "查看 Issue" / "打开 PRD" / "去审批"
+  url: string;
+  style?: 'primary' | 'default' | 'danger';
+}
+```
+
+Skill 输出 `links` → NanoClaw 侧按模板映射为 `card.actions`。
+
+### 5.2 流程状态条
+
+长耗时操作（PRD 生成、代码生成）返回 `status` 类型消息：
+
+- 初始态：`stage: 'generating_prd', progress: 0`
+- NanoClaw 订阅 Gateway 的进度事件（SSE 或轮询），逐步推送更新
+- 终态：`stage: 'done', progress: 100` + 附 `card` 展示产物
+
+### 5.3 Web 渲染
+
+AiChat 组件按消息 `type` 分发：
+
+- `text`：原样渲染
+- `card`：用现有 shadcn Card 组件，actions 转按钮
+- `status`：进度条 + 当前阶段文字
+
+### 5.4 验收标准
+
+1. Phase 2 的写工具回流全部是 card，用户点 "去审批" 跳 Plane 正确。
+2. `trigger_prd_generation` 全程能看到 status 更新（至少 3 个阶段：queued → generating → done）。
+3. 禁止使用 `window.prompt/alert/confirm`（见项目内 UI 规约）。
+
+## 6. 目录结构
+
+```text
+packages/nanoclaw-skills/arcflow-api/
+├── package.json
+├── src/
+│   ├── index.ts                  # 导出 skill 包
+│   ├── context.ts                # SkillContext + GatewayClient
+│   ├── tools/
+│   │   ├── list-my-issues.ts
+│   │   ├── read-prd.ts
+│   │   ├── search-docs.ts
+│   │   ├── get-workspace-info.ts
+│   │   ├── list-recent-activity.ts
+│   │   ├── create-requirement-draft.ts
+│   │   ├── trigger-prd-generation.ts
+│   │   └── update-issue-status.ts
+│   └── format/
+│       ├── card.ts               # 卡片模板
+│       └── status.ts             # 状态条模板
+└── __tests__/
+    └── ...（每个工具对应一份）
+```
+
+## 7. 测试策略
+
+- **单测**：每工具独立 mock `GatewayClient`，覆盖所有 case。
+- **契约测**：针对 Gateway 真实 OpenAPI 做 schema 校验，确保 skill 与后端漂移可感知。
+- **集成测**：起本地 Gateway + mock NanoClaw runtime，端到端跑 5 个只读工具。
+- **手测清单**（部署前）：在 Web AiChat 执行 15 条典型对话，覆盖 3 个 Phase 所有工具。
+
+## 8. 部署
+
+1. 本地 `bun build` 产出 dist。
+2. 推到 nanoclaw fork 的 `skills/arcflow-api/` 目录。
+3. 服务器 PM2 `arcflow-nanoclaw` 重启。
+4. 冷启后 `/data/project/nanoclaw` 应加载到新 skill（日志可见 `loaded skill: arcflow-api`）。
+
+## 9. 非目标（YAGNI）
+
+- 不做代码生成类工具（Claude Code headless 直接调，不经 NanoClaw）。
+- 不做审批回调（沿用 Plane Webhook → Gateway 现路径）。
+- 不做离线缓存。
+- 不做 skill 动态热加载（重启即可）。
+
+## 10. 风险与缓解
+
+| 风险 | 缓解 |
+|---|---|
+| Gateway API schema 漂移 | 契约测 + OpenAPI 锁版 |
+| 写工具被误触发造成脏数据 | 默认 `dryRun: true`，Prompt 侧强制先确认 |
+| NanoClaw fork 与上游冲突 | skill 代码与 fork 主干解耦，`skills/arcflow-api` 单独目录 |
+| 讯飞飞书 token 过期高频抖动 | Phase 0 已定义 `AUTH_EXPIRED` 回流机制 |

--- a/docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md
@@ -1,0 +1,182 @@
+# NanoClaw 鉴权透传设计（Phase 0）
+
+> 日期：2026-04-14（v2，修订：HTTP+SSE 架构 + 容器 credentials 挂载）
+> 分支：`feat/nanoclaw-auth-passthrough`
+> 关联 Epic：NanoClaw 作为 ArcFlow 核心入口（#85–#94）
+
+## 1. 背景与目标
+
+目标：让 Web AiChat → NanoClaw Web channel → 容器内 skill → Gateway 全链路带上真实用户身份（讯飞飞书 OAuth JWT）。
+
+修订原因（v1 → v2）：初稿假设 NanoClaw Web channel 是 WebSocket + 常驻 Node skill runtime。实际 NanoClaw 是 **HTTP POST + SSE + 每会话一个 Docker 容器**（`channels/web.ts` + `container-runner.ts`），架构本质不同，重写如下。
+
+当前状态：
+
+- ArcFlow Web 已对接讯飞飞书 OAuth，登录后在 localStorage 存 `arcflow_token`（JWT）。
+- Gateway 已新增 `POST /auth/verify`（Phase 0 Task 1-2 已落地）。
+- NanoClaw Web channel：`POST /api/chat` 收消息 + `GET /api/chat/sse?client_id=` 推回复，无鉴权。
+- 每个 chat 由 `container-runner` 启动一个 Docker 容器运行 Claude Code headless；skill 以文件挂载形式进入容器。
+
+## 2. 架构
+
+```text
+用户 → Web（arcflow_token in localStorage）
+        ↓ POST /api/chat  Header: Authorization: Bearer <token>
+        ↓ GET  /api/chat/sse?client_id=…&token=<token>   (EventSource 无法带 header，用 query)
+       NanoClaw Web channel
+        ↓ 首次见到 client_id 时，调用 Gateway /auth/verify 解析 token，
+          写入 ClientAuthStore[client_id] = {userId, workspaceId, token, expiresAt}
+        ↓ 派发到 container-runner 时，挂载临时凭证文件：
+          /run/arcflow/credentials.json → { token, userId, workspaceId, gatewayUrl }
+       Docker 容器（Claude Code headless）
+        ↓ skill 读取 /run/arcflow/credentials.json
+        ↓ curl Gateway 时用 Authorization: Bearer <token>
+       Gateway 复用现有 authMiddleware
+```
+
+硬约束：
+
+1. NanoClaw **不走 OAuth flow**，只做消费者。
+2. Token **不写日志、不落盘为长期存储**；ClientAuthStore 是内存 Map，凭证文件在容器停止后清理。
+3. Token 过期由 Web refresh 负责；NanoClaw 发 SSE `{type:"error", code:"AUTH_EXPIRED"}` 由 Web 处理。
+4. SSE query token 是退让方案（EventSource 限制）。Gateway 侧**禁止**在 access log 打印 query（运维 checklist）。
+
+## 3. 组件改动
+
+### 3.1 Gateway（已完成）
+
+`POST /auth/verify` 已实现，Task 1–2 已合并到 `feat/nanoclaw-auth-passthrough`。无需二次改动。
+
+### 3.2 NanoClaw Web channel — HTTP 鉴权
+
+**POST /api/chat**：
+
+- 必须携带 `Authorization: Bearer <arcflow_token>`，否则返 `401 {code:"AUTH_INVALID"}`。
+- 首次见到 `client_id` 时，调用 Gateway `/auth/verify`，缓存到 `ClientAuthStore`。
+- token 变化（用户重登）也要刷新 store。
+- Gateway 返 `AUTH_EXPIRED` → 返 `401 {code:"AUTH_EXPIRED"}`，让 Web 触发 refresh。
+
+**GET /api/chat/sse**：
+
+- `?token=<arcflow_token>` 必须带，否则 `401`。
+- 校验 token 对应 client_id 的 store（防止窃用）。
+- 无 store 则先调 `/auth/verify` 建立。
+
+**ClientAuthStore**（内存 Map）：
+
+```ts
+interface ClientAuth {
+  userId: number;
+  workspaceId: number;
+  displayName: string;
+  token: string;
+  expiresAt: number; // unix seconds
+}
+const store = new Map<string /* client_id */, ClientAuth>();
+```
+
+### 3.3 Container runner — 凭证文件挂载
+
+启动容器时，为每个 chat 生成一个临时凭证文件并 mount 到 `/run/arcflow/credentials.json`：
+
+```ts
+// container-runner.ts 启动逻辑新增：
+const credPath = await writeTempCredentials({
+  token: auth.token,
+  userId: auth.userId,
+  workspaceId: auth.workspaceId,
+  gatewayUrl: process.env.GATEWAY_URL,
+});
+dockerArgs.push('-v', `${credPath}:/run/arcflow/credentials.json:ro`);
+// 容器退出时清理
+onContainerExit(() => fs.unlink(credPath));
+```
+
+**为什么挂载而不是 env：**
+
+- env 在容器内任何进程（包括 `ps`/`/proc/*/environ`）都可见
+- 挂载文件权限 0400 + 容器内 readonly + 退出即删，泄露面小
+
+### 3.4 Skill 侧约定（Phase 1 的预备）
+
+容器内 skill 读取凭证：
+
+```bash
+# shell skill 示例
+TOKEN=$(jq -r .token /run/arcflow/credentials.json)
+GATEWAY=$(jq -r .gatewayUrl /run/arcflow/credentials.json)
+curl -H "Authorization: Bearer $TOKEN" "$GATEWAY/api/issues"
+```
+
+Phase 0 只验证读凭证 + 调 Gateway 能通，不落实际 skill。
+
+### 3.5 Web — AiChat 请求改造
+
+**POST 消息**：fetch 加 `Authorization` header。
+
+**SSE 订阅**：`new EventSource('/api/chat/sse?client_id=' + id + '&token=' + arcflowToken)`。
+
+- 收到 `{type:"error", code:"AUTH_EXPIRED"}` → 关闭 SSE → 调 refresh → 重连（携带新 token）→ 重发未 ack 的消息（可选，简化版直接让用户重试）。
+
+## 4. 数据流示例
+
+```text
+Web → POST /api/chat
+      Authorization: Bearer jwt.ok
+      { client_id: "c-123", message: "列出我的 issue" }
+NanoClaw → Gateway /auth/verify → { userId:7, workspaceId:3, … }
+         → store["c-123"] = {...}
+         → onMessage 触发 container-runner
+         → 写 /tmp/arcflow-creds-c-123.json（mode 0400）
+         → docker run -v …/creds.json:/run/arcflow/credentials.json:ro
+         → 容器内 skill 读凭证 → curl Gateway → 返 issue 列表
+         → 容器 stdout 被 NanoClaw 捕获 → SSE push 给 Web
+```
+
+## 5. 错误路径
+
+| 场景 | 行为 |
+|---|---|
+| POST 无 Authorization | 401 `{code:"AUTH_INVALID"}` |
+| SSE 无 token | 401 `{code:"AUTH_INVALID"}` |
+| Token 过期 | 401 `{code:"AUTH_EXPIRED"}`，SSE 则推 error event 后关闭 |
+| Gateway `/auth/verify` 不可达 | 502 `{code:"GATEWAY_UNREACHABLE"}` |
+| 容器启动失败（凭证写入失败） | 500，服务器日志告警 |
+| 容器内 skill 拿到 token 但 Gateway 返 401 | skill 进程输出 `AUTH_EXPIRED`，NanoClaw SSE 推错误事件 |
+
+## 6. 测试策略
+
+- **Gateway**：`/auth/verify` 单测已覆盖（Task 2）。
+- **NanoClaw Web channel**：
+  - 无 Authorization POST → 401
+  - 带有效 token POST → onMessage 被调用，ClientAuthStore 命中
+  - 过期 token POST → 401 AUTH_EXPIRED
+  - SSE 无 token → 401
+  - SSE 带 token → 连接建立
+- **container-runner**：
+  - 凭证文件写入 + 挂载参数正确
+  - 容器退出后凭证文件被清理
+  - 凭证文件权限 0400
+- **Web**：`AUTH_EXPIRED` → refresh + 重连 SSE 单测。
+- **手测**：Web 登录 → AiChat 发消息 → 容器内 `cat /run/arcflow/credentials.json` 可见正确 token；手工过期 token → Web 自动 refresh + 重连。
+
+## 7. 非目标（YAGNI）
+
+- 不做 NanoClaw 独立 OAuth client。
+- 不做 refresh token 本地维护（Web 负责）。
+- 不做细粒度权限（workspace 级足够）。
+- 不做 SSE query token 加密（HTTPS 已保障传输，禁止日志是运维层约束）。
+- 不做 skill 层缓存 user context（每次读凭证文件，简单）。
+
+## 8. 验收标准
+
+1. ✅ Gateway `/auth/verify` 通过单测（Task 2 已完成）。
+2. NanoClaw POST/SSE 拒绝无 token 请求。
+3. POST 带有效 token → ClientAuthStore 命中 + onMessage 触发。
+4. container-runner 正确挂载凭证文件（mode 0400，readonly，退出清理）。
+5. 容器内 `jq -r .token /run/arcflow/credentials.json` 可读；调 Gateway 可通。
+6. Token 过期 → Web 自动 refresh + 重连 SSE 成功。
+
+## 9. 后续依赖
+
+Phase 1（arcflow-api skill MVP）在容器内读凭证直接调 Gateway，不再处理鉴权。

--- a/packages/gateway/src/routes/auth.test.ts
+++ b/packages/gateway/src/routes/auth.test.ts
@@ -9,9 +9,10 @@ mock.module("../config", () => ({
     }),
 }));
 
+import { SignJWT } from "jose";
 import { authRoutes } from "./auth";
 import { signJwt } from "../services/auth";
-import { upsertUser } from "../db/queries";
+import { upsertUser, createWorkspace, addWorkspaceMember } from "../db/queries";
 
 describe("auth routes", () => {
   beforeEach(() => {
@@ -44,5 +45,45 @@ describe("auth routes", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.name).toBe("Test User");
+  });
+
+  it("POST /auth/verify returns user context with valid bearer", async () => {
+    const user = upsertUser({ feishu_user_id: "ou_v1", name: "Verify User" });
+    const ws = createWorkspace({ name: "WV", slug: "wv-verify" });
+    addWorkspaceMember(ws.id, user.id, "admin");
+    const token = await signJwt({ sub: user.id, role: "member" });
+    const res = await authRoutes.request("/auth/verify", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.code).toBe(0);
+    expect(body.data.userId).toBe(user.id);
+    expect(body.data.workspaceId).toBe(ws.id);
+    expect(body.data.displayName).toBe("Verify User");
+  });
+
+  it("POST /auth/verify returns 401 AUTH_INVALID when bearer missing", async () => {
+    const res = await authRoutes.request("/auth/verify", { method: "POST" });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe("AUTH_INVALID");
+  });
+
+  it("POST /auth/verify returns 401 AUTH_EXPIRED on expired token", async () => {
+    const secret = new TextEncoder().encode(createTestConfig().jwtSecret);
+    const token = await new SignJWT({ sub: 1, role: "member" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(secret);
+    const res = await authRoutes.request("/auth/verify", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.code).toBe("AUTH_EXPIRED");
   });
 });

--- a/packages/gateway/src/routes/auth.ts
+++ b/packages/gateway/src/routes/auth.ts
@@ -1,5 +1,10 @@
 import { Hono } from "hono";
-import { generateOAuthUrl, exchangeCodeForUser, signJwt } from "../services/auth";
+import {
+  generateOAuthUrl,
+  exchangeCodeForUser,
+  signJwt,
+  resolveUserContext,
+} from "../services/auth";
 import { upsertUser, getUserById } from "../db/queries";
 import { authMiddleware } from "../middleware/auth";
 import { getConfig } from "../config";
@@ -38,6 +43,23 @@ authRoutes.get("/callback", async (c) => {
       { error: `OAuth failed: ${err instanceof Error ? err.message : "unknown"}` },
       500,
     );
+  }
+});
+
+// NanoClaw 用：解析 arcflow_token 返回 user/workspace 上下文
+authRoutes.post("/auth/verify", async (c) => {
+  const header = c.req.header("Authorization");
+  if (!header?.startsWith("Bearer ")) {
+    return c.json({ code: "AUTH_INVALID", message: "Missing bearer" }, 401);
+  }
+  const token = header.slice(7);
+  try {
+    const data = await resolveUserContext(token);
+    return c.json({ code: 0, data });
+  } catch (err) {
+    const code =
+      err instanceof Error && err.message === "AUTH_EXPIRED" ? "AUTH_EXPIRED" : "AUTH_INVALID";
+    return c.json({ code, message: code }, 401);
   }
 });
 

--- a/packages/gateway/src/services/auth.test.ts
+++ b/packages/gateway/src/services/auth.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, afterEach, mock } from "bun:test";
+import { SignJWT } from "jose";
 import { closeDb } from "../db";
 import { createTestConfig } from "../test-config";
 
@@ -9,7 +10,8 @@ mock.module("../config", () => ({
     }),
 }));
 
-import { generateOAuthUrl, signJwt, verifyJwt } from "./auth";
+import { generateOAuthUrl, signJwt, verifyJwt, resolveUserContext } from "./auth";
+import { upsertUser, createWorkspace, addWorkspaceMember } from "../db/queries";
 
 describe("auth service", () => {
   afterEach(() => {
@@ -35,5 +37,49 @@ describe("auth service", () => {
 
   it("rejects invalid JWT", async () => {
     await expect(verifyJwt("invalid-token")).rejects.toThrow();
+  });
+});
+
+describe("resolveUserContext", () => {
+  afterEach(() => {
+    closeDb();
+  });
+
+  it("valid token returns user + first workspace context", async () => {
+    const user = upsertUser({
+      feishu_user_id: "ou_rc_1",
+      feishu_union_id: "on_rc_1",
+      name: "Ctx User",
+      avatar_url: "",
+      email: "c@x.cn",
+    });
+    const ws = createWorkspace({ name: "W1", slug: "w1-rc" });
+    addWorkspaceMember(ws.id, user.id, "admin");
+    const token = await signJwt({ sub: user.id, role: user.role });
+
+    const ctx = await resolveUserContext(token);
+    expect(ctx.userId).toBe(user.id);
+    expect(ctx.displayName).toBe("Ctx User");
+    expect(ctx.workspaceId).toBe(ws.id);
+    expect(ctx.expiresAt).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("expired token throws AUTH_EXPIRED", async () => {
+    const secret = new TextEncoder().encode(createTestConfig().jwtSecret);
+    const token = await new SignJWT({ sub: 1, role: "member" })
+      .setProtectedHeader({ alg: "HS256" })
+      .setIssuedAt(Math.floor(Date.now() / 1000) - 3600)
+      .setExpirationTime(Math.floor(Date.now() / 1000) - 60)
+      .sign(secret);
+    await expect(resolveUserContext(token)).rejects.toThrow("AUTH_EXPIRED");
+  });
+
+  it("invalid token throws AUTH_INVALID", async () => {
+    await expect(resolveUserContext("garbage.not.jwt")).rejects.toThrow("AUTH_INVALID");
+  });
+
+  it("unknown user throws AUTH_INVALID", async () => {
+    const token = await signJwt({ sub: 999999, role: "member" });
+    await expect(resolveUserContext(token)).rejects.toThrow("AUTH_INVALID");
   });
 });

--- a/packages/gateway/src/services/auth.ts
+++ b/packages/gateway/src/services/auth.ts
@@ -1,5 +1,35 @@
-import { SignJWT, jwtVerify } from "jose";
+import { SignJWT, jwtVerify, errors as joseErrors } from "jose";
 import { getConfig } from "../config";
+import { getUserById, listUserWorkspaces } from "../db/queries";
+
+export interface UserContext {
+  userId: number;
+  displayName: string;
+  workspaceId: number;
+  expiresAt: number;
+}
+
+export async function resolveUserContext(token: string): Promise<UserContext> {
+  const config = getConfig();
+  const secret = new TextEncoder().encode(config.jwtSecret);
+  let payload;
+  try {
+    const result = await jwtVerify(token, secret);
+    payload = result.payload;
+  } catch (err) {
+    if (err instanceof joseErrors.JWTExpired) throw new Error("AUTH_EXPIRED");
+    throw new Error("AUTH_INVALID");
+  }
+  const user = getUserById(payload.sub as number);
+  if (!user) throw new Error("AUTH_INVALID");
+  const workspaces = listUserWorkspaces(user.id);
+  return {
+    userId: user.id,
+    displayName: user.name,
+    workspaceId: workspaces[0]?.id ?? 0,
+    expiresAt: Number(payload.exp ?? 0),
+  };
+}
 
 export function generateOAuthUrl(): string {
   const config = getConfig();

--- a/packages/web/src/api/nanoclaw.test.ts
+++ b/packages/web/src/api/nanoclaw.test.ts
@@ -1,0 +1,79 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from "vitest";
+
+// Mock fetch globally
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+// VITE_NANOCLAW_BASE is empty in test env — URLs are relative (/api/chat/...)
+
+import { postChat, openChatStream } from "./nanoclaw";
+
+describe("postChat", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("sends Authorization header with token", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ ok: true, message_id: "m-1" }),
+    });
+
+    await postChat({ clientId: "c-1", message: "hello", token: "jwt.abc", workspaceId: 3 });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer jwt.abc");
+  });
+
+  it("returns ok:false on 401", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ code: "AUTH_EXPIRED" }),
+    });
+
+    const result = await postChat({ clientId: "c-1", message: "hi", token: "t", workspaceId: 1 });
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("openChatStream", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("passes token as ?token= query param", async () => {
+    // Return a never-resolving readable stream
+    const controller = new AbortController();
+    mockFetch.mockImplementation(async (url: string) => {
+      expect(url).toContain("token=jwt.sse");
+      return {
+        ok: true,
+        body: new ReadableStream({
+          start(c) {
+            // Hold open
+            controller.signal.addEventListener("abort", () => c.close());
+          },
+        }),
+      };
+    });
+
+    const ac = openChatStream(
+      { clientId: "c-2", token: "jwt.sse", workspaceId: 3 },
+      { onEvent: vi.fn() },
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    ac.abort();
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const url: string = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("token=jwt.sse");
+  });
+});

--- a/packages/web/src/api/nanoclaw.ts
+++ b/packages/web/src/api/nanoclaw.ts
@@ -84,9 +84,8 @@ export function openChatStream(
   handlers: NanoClawStreamHandlers,
 ): AbortController {
   const controller = new AbortController();
-  const url = `${NANOCLAW_BASE}/api/chat/sse?client_id=${encodeURIComponent(params.clientId)}`;
+  const url = `${NANOCLAW_BASE}/api/chat/sse?client_id=${encodeURIComponent(params.clientId)}&token=${encodeURIComponent(params.token)}`;
   const headers: Record<string, string> = {
-    Authorization: `Bearer ${params.token}`,
     "X-Workspace-Id": String(params.workspaceId),
     Accept: "text/event-stream",
   };

--- a/packages/web/src/composables/useAiChat.test.ts
+++ b/packages/web/src/composables/useAiChat.test.ts
@@ -1,0 +1,36 @@
+import { vi, describe, it, expect } from "vitest";
+import { createSseAuthHandler } from "./useAiChat";
+
+describe("SSE auth handling", () => {
+  it("on AUTH_EXPIRED calls refresh + reconnect", async () => {
+    const refresh = vi.fn().mockResolvedValue("new.token");
+    const reconnect = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect });
+    await h({ type: "error", code: "AUTH_EXPIRED" });
+    expect(refresh).toHaveBeenCalled();
+    expect(reconnect).toHaveBeenCalled();
+  });
+
+  it("on refresh failure redirects to login", async () => {
+    const refresh = vi.fn().mockRejectedValue(new Error("x"));
+    const redirect = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect: () => {}, redirect });
+    await h({ type: "error", code: "AUTH_EXPIRED" });
+    expect(redirect).toHaveBeenCalledWith("/login");
+  });
+
+  it("ignores non-AUTH_EXPIRED errors", async () => {
+    const refresh = vi.fn();
+    const reconnect = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect });
+    await h({ type: "error", code: "AUTH_INVALID" });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-error events", async () => {
+    const refresh = vi.fn();
+    const h = createSseAuthHandler({ refresh, reconnect: vi.fn() });
+    await h({ type: "message" });
+    expect(refresh).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/composables/useAiChat.ts
+++ b/packages/web/src/composables/useAiChat.ts
@@ -1,0 +1,20 @@
+/**
+ * SSE auth handler for NanoClaw WebChannel.
+ * Exported as a pure function so it can be unit-tested without Vue.
+ */
+export function createSseAuthHandler(deps: {
+  refresh: () => Promise<string>;
+  reconnect: () => void;
+  redirect?: (path: string) => void;
+}) {
+  return async (msg: { type: string; code?: string }) => {
+    if (msg.type === "error" && msg.code === "AUTH_EXPIRED") {
+      try {
+        await deps.refresh();
+        deps.reconnect();
+      } catch {
+        deps.redirect?.("/login");
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary

NanoClaw 鉴权透传 Phase 0 — ArcFlow 侧改动（Gateway + Web）。配合 nanoclaw fork PR。

- Gateway 新增 `resolveUserContext` 与 `POST /auth/verify`，用于 NanoClaw 缓存用户身份。
- Web `AiChat` 的 POST `/api/chat` 带 `Authorization: Bearer <arcflow_token>`。
- Web SSE 订阅改用 `?token=` query（EventSource 不支持自定义 header），并提供 `createSseAuthHandler` 处理 `AUTH_EXPIRED` → refresh → 重连。

## 关联
- Spec: `docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md`
- Plan: `docs/superpowers/plans/2026-04-14-nanoclaw-auth-passthrough.md`
- NanoClaw fork PR: ssyamv/nanoclaw#<pending>

## Test plan
- [x] Gateway `/auth/verify` 单测通过
- [x] Web `nanoclaw.ts` POST 鉴权单测 2/2
- [x] Web `useAiChat` `createSseAuthHandler` 单测 4/4
- [ ] 本地三端 e2e 6 路径（spec §8）— 由人类验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)