### PR TITLE
feat(nanoclaw): auth passthrough + chat UX fixes

### DIFF
--- a/docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md
+++ b/docs/superpowers/specs/2026-04-14-nanoclaw-auth-passthrough-design.md
@@ -171,11 +171,11 @@ NanoClaw → Gateway /auth/verify → { userId:7, workspaceId:3, … }
 ## 8. 验收标准
 
 1. ✅ Gateway `/auth/verify` 通过单测（Task 2 已完成）。
-2. NanoClaw POST/SSE 拒绝无 token 请求。
-3. POST 带有效 token → ClientAuthStore 命中 + onMessage 触发。
-4. container-runner 正确挂载凭证文件（mode 0400，readonly，退出清理）。
-5. 容器内 `jq -r .token /run/arcflow/credentials.json` 可读；调 Gateway 可通。
-6. Token 过期 → Web 自动 refresh + 重连 SSE 成功。
+2. ✅ NanoClaw POST/SSE 拒绝无 token 请求（`web.test.ts` 15/15，含 401 AUTH_INVALID / AUTH_EXPIRED 负路径）。
+3. ✅ POST 带有效 token → ClientAuthStore 命中 + onMessage 触发（`web.test.ts`）。
+4. ✅ container-runner 正确挂载凭证文件 mode 0400/readonly/退出清理（`credentials-file.test.ts` + `container-runner.test.ts` 6/6）。
+5. ⬜ 容器内 `jq -r .token /run/arcflow/credentials.json` 可读；调 Gateway 可通（需人工起 Docker + Gateway 验证，见 plan Task 10 步骤 1–2）。
+6. ⬜ Token 过期 → Web 自动 refresh + 重连 SSE 成功（`useAiChat.test.ts` 单测覆盖 handler 逻辑；端到端 refresh + 重连需人工）。
 
 ## 9. 后续依赖
 

--- a/packages/gateway/src/routes/conversations.test.ts
+++ b/packages/gateway/src/routes/conversations.test.ts
@@ -74,6 +74,38 @@ describe("conversation routes", () => {
     expect(body.data.length).toBe(2);
   });
 
+  it("POST /:id/messages persists assistant message", async () => {
+    const conv = createConversation(userId, "Chat");
+    const res = await conversationRoutes.request(`/${conv.id}/messages`, {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "assistant", content: "hello from nanoclaw" }),
+    });
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.role).toBe("assistant");
+    expect(body.content).toBe("hello from nanoclaw");
+  });
+
+  it("POST /:id/messages rejects invalid role", async () => {
+    const conv = createConversation(userId, "Chat");
+    const res = await conversationRoutes.request(`/${conv.id}/messages`, {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "system", content: "x" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /:id/messages 404 when conversation missing", async () => {
+    const res = await conversationRoutes.request(`/99999/messages`, {
+      method: "POST",
+      headers: { ...headers(), "Content-Type": "application/json" },
+      body: JSON.stringify({ role: "user", content: "x" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
   it("GET /search?q= searches conversations", async () => {
     const conv = createConversation(userId, "Project Alpha");
     createMessage(conv.id, "user", "Tell me about the API design");

--- a/packages/gateway/src/routes/conversations.ts
+++ b/packages/gateway/src/routes/conversations.ts
@@ -9,6 +9,7 @@ import {
   deleteConversation,
   searchConversations,
   listMessages,
+  createMessage,
 } from "../db/queries";
 
 export const conversationRoutes = new Hono();
@@ -61,4 +62,21 @@ conversationRoutes.get("/:id/messages", (c) => {
   if (!conv) return c.json({ error: "Not found" }, 404);
   const data = listMessages(id);
   return c.json({ data });
+});
+
+conversationRoutes.post("/:id/messages", async (c) => {
+  const userId = c.get("userId") as number;
+  const id = Number(c.req.param("id"));
+  const conv = getConversation(id, userId);
+  if (!conv) return c.json({ error: "Not found" }, 404);
+  const body = await c.req
+    .json<{ role?: "user" | "assistant"; content?: string }>()
+    .catch(() => ({}) as { role?: "user" | "assistant"; content?: string });
+  const role = body.role;
+  const content = typeof body.content === "string" ? body.content : "";
+  if ((role !== "user" && role !== "assistant") || !content.trim()) {
+    return c.json({ error: "Invalid role or content" }, 400);
+  }
+  const msg = createMessage(id, role, content);
+  return c.json(msg, 201);
 });

--- a/packages/web/src/api/requirement.ts
+++ b/packages/web/src/api/requirement.ts
@@ -60,7 +60,7 @@ export function createRequirementDraft(params: {
 }
 
 export function getRequirementDraft(id: number): Promise<RequirementDraft> {
-  return request<RequirementDraft>(`/api/requirement/draft/${id}`);
+  return request<RequirementDraft>(`/api/requirement/${id}`);
 }
 
 export function listRequirementDrafts(params: {
@@ -72,7 +72,7 @@ export function listRequirementDrafts(params: {
   if (params.workspace_id) q.set("workspace_id", String(params.workspace_id));
   if (params.status) q.set("status", params.status);
   if (params.limit) q.set("limit", String(params.limit));
-  return request<RequirementDraftListResponse>(`/api/requirement/drafts?${q}`);
+  return request<RequirementDraftListResponse>(`/api/requirement?${q}`);
 }
 
 export function patchRequirementDraft(

--- a/packages/web/src/pages/AiChat.vue
+++ b/packages/web/src/pages/AiChat.vue
@@ -149,7 +149,14 @@
               </div>
 
               <!-- Assistant message -->
-              <div class="prose text-sm" v-html="renderMd(msg.content)" />
+              <div class="prose text-sm">
+                <span v-html="renderMd(msg.content)" /><span
+                  v-if="chatStore.streamingId === msg.id"
+                  class="streaming-cursor"
+                  aria-hidden="true"
+                  >▍</span
+                >
+              </div>
 
               <!-- Artifacts -->
               <div
@@ -175,8 +182,15 @@
               </div>
             </div>
           </div>
-          <div v-if="chatStore.typing" class="text-sm" style="color: var(--color-text-tertiary)">
-            <span class="animate-pulse">···</span>
+          <div
+            v-if="chatStore.typing && !hasStreamingContent"
+            class="text-sm flex items-center gap-1"
+            style="color: var(--color-text-tertiary)"
+          >
+            <span class="thinking-dot" />
+            <span class="thinking-dot" style="animation-delay: 0.15s" />
+            <span class="thinking-dot" style="animation-delay: 0.3s" />
+            <span class="ml-1 text-xs">思考中…</span>
           </div>
         </div>
 
@@ -318,8 +332,14 @@ async function handleSend() {
   if (!input.value.trim() || !convStore.currentId) return;
   const msg = input.value;
   input.value = "";
-  const conv = convStore.conversations.find((c) => c.id === convStore.currentId);
-  await chatStore.send(convStore.currentId, msg, conv?.dify_conversation_id ?? undefined);
+  const convId = convStore.currentId;
+  const conv = convStore.conversations.find((c) => c.id === convId);
+  const shouldAutoTitle = !!conv && (!conv.title || conv.title === "新对话");
+  if (shouldAutoTitle) {
+    const title = msg.replace(/\s+/g, " ").trim().slice(0, 24);
+    if (title) void convStore.update(convId, { title });
+  }
+  await chatStore.send(convId, msg, conv?.dify_conversation_id ?? undefined);
   scrollToBottom();
 }
 
@@ -344,7 +364,19 @@ function scrollToBottom() {
   });
 }
 
+const hasStreamingContent = computed(() => {
+  const id = chatStore.streamingId;
+  if (id == null) return false;
+  const m = chatStore.messages.find((x) => x.id === id);
+  return !!m && m.content.length > 0;
+});
+
 watch(() => chatStore.messages.length, scrollToBottom);
+watch(() => {
+  const id = chatStore.streamingId;
+  if (id == null) return "";
+  return chatStore.messages.find((x) => x.id === id)?.content ?? "";
+}, scrollToBottom);
 
 onMounted(() => {
   convStore.load();
@@ -357,5 +389,37 @@ onMounted(() => {
   font-weight: 510;
   color: var(--color-text-quaternary);
   padding: 8px 12px 4px;
+}
+.thinking-dot {
+  display: inline-block;
+  width: 5px;
+  height: 5px;
+  border-radius: 9999px;
+  background-color: currentColor;
+  opacity: 0.4;
+  animation: thinking-bounce 1s infinite ease-in-out;
+}
+@keyframes thinking-bounce {
+  0%,
+  80%,
+  100% {
+    transform: scale(0.6);
+    opacity: 0.3;
+  }
+  40% {
+    transform: scale(1);
+    opacity: 0.9;
+  }
+}
+.streaming-cursor {
+  display: inline-block;
+  margin-left: 2px;
+  color: var(--color-accent);
+  animation: cursor-blink 1s steps(2) infinite;
+}
+@keyframes cursor-blink {
+  50% {
+    opacity: 0;
+  }
 }
 </style>

--- a/packages/web/src/stores/chat.ts
+++ b/packages/web/src/stores/chat.ts
@@ -41,7 +41,31 @@ export const useChatStore = defineStore("chat", () => {
   const sidecars = ref<Record<number, MessageSidecar>>({});
   const loading = ref(false);
   const typing = ref(false);
+  const streamingId = ref<number | null>(null);
   const error = ref<string | null>(null);
+
+  async function persistMessage(
+    conversationId: number,
+    role: "user" | "assistant",
+    content: string,
+  ) {
+    if (!content.trim()) return;
+    const token = localStorage.getItem("arcflow_token");
+    const wsId = localStorage.getItem("arcflow_workspace_id");
+    try {
+      await fetch(`${API_BASE}/api/conversations/${conversationId}/messages`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(wsId ? { "X-Workspace-Id": wsId } : {}),
+        },
+        body: JSON.stringify({ role, content }),
+      });
+    } catch (e) {
+      console.warn("persistMessage failed", e);
+    }
+  }
 
   async function loadMessages(conversationId: number) {
     loading.value = true;
@@ -162,12 +186,17 @@ export const useChatStore = defineStore("chat", () => {
     };
     messages.value.push(aiMsg);
     sidecars.value[aiMsg.id] = blankSidecar();
+    streamingId.value = aiMsg.id;
 
     const sidecar = sidecars.value[aiMsg.id];
 
+    // Persist user message (best-effort) so it survives reload even if the
+    // stream is interrupted before the assistant reply lands.
+    void persistMessage(conversationId, "user", message);
+
     // Open SSE stream BEFORE posting so we don't miss session_start.
     let settled = false;
-    let controller: AbortController | null = null;
+    let controller: AbortController | undefined;
     const doneP = new Promise<void>((resolve) => {
       controller = openChatStream(
         {
@@ -180,7 +209,9 @@ export const useChatStore = defineStore("chat", () => {
             handleNanoClawEvent(ev, aiMsg, sidecar);
             const isLegacyDone =
               ev.type === "message" && (ev.data as { done?: boolean })?.done === true;
-            if ((ev.type === "done" || isLegacyDone) && !settled) {
+            // message_end marks end-of-assistant-turn per spec §6 — don't
+            // wait for an additional `done` that NanoClaw may never send.
+            if ((ev.type === "done" || ev.type === "message_end" || isLegacyDone) && !settled) {
               settled = true;
               resolve();
             }
@@ -216,6 +247,10 @@ export const useChatStore = defineStore("chat", () => {
         controller?.abort();
       } else {
         await doneP;
+        // Close the SSE connection once the turn is settled so the server
+        // doesn't keep pumping heartbeats and the client doesn't keep the
+        // stream half-open (which looked like a mid-stream interruption).
+        controller?.abort();
       }
     } catch (e) {
       error.value = e instanceof Error ? e.message : "发送失败";
@@ -223,6 +258,10 @@ export const useChatStore = defineStore("chat", () => {
     } finally {
       loading.value = false;
       typing.value = false;
+      streamingId.value = null;
+      if (aiMsg.content.trim()) {
+        void persistMessage(conversationId, "assistant", aiMsg.content);
+      }
     }
   }
 
@@ -318,6 +357,7 @@ export const useChatStore = defineStore("chat", () => {
     sidecars,
     loading,
     typing,
+    streamingId,
     error,
     loadMessages,
     send,

--- a/packages/web/src/stores/chat.ts
+++ b/packages/web/src/stores/chat.ts
@@ -178,7 +178,9 @@ export const useChatStore = defineStore("chat", () => {
         {
           onEvent(ev: NanoClawEvent) {
             handleNanoClawEvent(ev, aiMsg, sidecar);
-            if (ev.type === "done" && !settled) {
+            const isLegacyDone =
+              ev.type === "message" && (ev.data as { done?: boolean })?.done === true;
+            if ((ev.type === "done" || isLegacyDone) && !settled) {
               settled = true;
               resolve();
             }
@@ -286,8 +288,14 @@ export const useChatStore = defineStore("chat", () => {
       case "error":
         error.value = typeof data?.message === "string" ? data.message : "NanoClaw 错误";
         break;
+      case "message": {
+        // Legacy NanoClaw event: whole assistant message in one shot.
+        const c = typeof data?.content === "string" ? data.content : "";
+        if (c) aiMsg.content += c;
+        break;
+      }
       default:
-        // session_start / message_end / done / connected / legacy — no-op
+        // session_start / message_end / done / connected — no-op
         break;
     }
   }


### PR DESCRIPTION
## Summary
- Gateway: `POST /auth/verify` + `resolveUserContext` for NanoClaw token → user/workspace resolution
- Gateway: `POST /api/conversations/:id/messages` so NanoClaw path can persist history
- Web: SSE uses token query + `X-Workspace-Id`, AUTH_EXPIRED refresh, legacy `message` event rendering
- Web: streaming indicator (思考中… → cursor), treat `message_end` as turn-complete, abort SSE after settle
- Web: persist user + assistant messages, auto-name brand-new conversations
- Web: fix `/api/requirement/drafts` → `/api/requirement` (was 400 Invalid ID)

## Test plan
- [x] `bun test packages/gateway` — conversations + existing routes green
- [x] `vue-tsc --noEmit` clean
- [ ] Live e2e: send message in web, verify streaming cursor, reload keeps history, conversation auto-renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)