### PR TITLE
fix(gateway): add minimatch dep + named import

### DIFF
--- a/packages/gateway/package.json
+++ b/packages/gateway/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "hono": "^4.0.0",
     "jose": "^6.2.2",
+    "minimatch": "^10.2.5",
     "simple-git": "^3.33.0",
     "sqlite-vec": "^0.1.9"
   },

--- a/packages/gateway/src/services/rag-git-adapter.ts
+++ b/packages/gateway/src/services/rag-git-adapter.ts
@@ -1,7 +1,7 @@
 import { execSync } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import minimatch from "minimatch";
+import { minimatch } from "minimatch";
 import type { GitAdapter } from "./rag-index";
 
 export interface GitAdapterConfig {


### PR DESCRIPTION
Hotfix for #113: rag-git-adapter imports minimatch but the package was not declared in gateway/package.json, so docker build failed at runtime with 'Cannot find package minimatch'.

Also switched to named import for minimatch v10 compatibility (default export was removed).

Required to unblock Dify → NanoClaw deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)