### PR TITLE
[codex] close p0 callbacks and align p1 deployment flow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
         run: sudo apt-get install -y lcov
       - name: Check coverage
         run: |
+          mkdir -p packages/gateway/coverage
           lcov -a packages/gateway/coverage-base/lcov.info -a packages/gateway/coverage-workflow/lcov.info -o packages/gateway/coverage/lcov.info
           COVERAGE=$(lcov --summary packages/gateway/coverage/lcov.info 2>&1 | grep 'lines' | grep -o '[0-9.]*%' | head -1 | tr -d '%')
           echo "Coverage: ${COVERAGE}%"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,13 +87,20 @@ jobs:
           bun-version: 1.2.17
       - run: bun install
       - name: Run tests
-        run: bun run test
+        run: |
+          rm -rf coverage coverage-base coverage-workflow
+          bun test --coverage --coverage-reporter lcov src/{index,config}.test.ts src/middleware/ src/routes/{api,auth,conversations,health,workspaces,batch-2f}.test.ts src/services/{feishu,git,claude-code,plane,plane-webhook,ibuild,ibuild-log-fetcher,prd,rag-sync,auth}.test.ts
+          mv coverage coverage-base
+          bun test --coverage --coverage-reporter lcov src/index.test.ts src/services/workflow-writeback.test.ts src/services/workflow-callback.test.ts
+          mv coverage coverage-workflow
+          bun test src/db/ && bun test src/scheduler.test.ts src/services/workflow.test.ts && bun test src/routes/docs.test.ts && bun test src/routes/webhook.test.ts
         working-directory: packages/gateway
         timeout-minutes: 3
       - name: Install lcov
         run: sudo apt-get install -y lcov
       - name: Check coverage
         run: |
+          lcov -a packages/gateway/coverage-base/lcov.info -a packages/gateway/coverage-workflow/lcov.info -o packages/gateway/coverage/lcov.info
           COVERAGE=$(lcov --summary packages/gateway/coverage/lcov.info 2>&1 | grep 'lines' | grep -o '[0-9.]*%' | head -1 | tr -d '%')
           echo "Coverage: ${COVERAGE}%"
           if (( $(echo "$COVERAGE < 50" | bc -l) )); then

--- a/README.md
+++ b/README.md
@@ -163,6 +163,16 @@ docker compose up -d
 - [setup/plane](setup/plane)
 - [setup/nanoclaw/README.md](setup/nanoclaw/README.md)
 - [setup/docs-repo/README.md](setup/docs-repo/README.md)
+- [setup/production-runbook.md](setup/production-runbook.md)
+
+### 生产部署口径
+
+当前生产部署与排障统一以 [setup/production-runbook.md](setup/production-runbook.md) 为准。
+
+当前单一可信路径：
+
+- ArcFlow：`/data/project/arcflow`
+- NanoClaw：`/data/project/nanoclaw`
 
 关键验证记录：
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 - 以本文件和 [docs/AI研发运营一体化平台_技术架构方案.md](docs/AI研发运营一体化平台_技术架构方案.md) 作为当前架构与开发状态的权威说明。
 - `docs/superpowers/specs/`、`plans/`、`reports/` 中保留了完整演进记录，但其中一部分属于历史方案。请先查看 [docs/documentation-status.md](docs/documentation-status.md) 了解哪些文档是当前参考、哪些仅供历史追溯。
+- 当前说明已对齐到 `2026-04-17` 仓库状态：Phase 3.5 本仓闭环与 CI bug 回流闭环均已有对应验证记录。
 
 ## 项目目标
 
@@ -92,9 +93,10 @@ ArcFlow/
 | Phase 3.2 | Web AiChat 切 NanoClaw、鉴权透传、memory snapshot | 已完成 |
 | Phase 3.3 | NanoClaw 上线与生产环境对齐 | 已完成 |
 | Phase 3.4 | `arcflow-api` 交互链路：ArcFlow 侧 Gateway 契约与 Web artifact 渲染 | 已完成 |
-| Phase 3.4b | `arcflow-api` skill 包在 NanoClaw 仓内的发布、接线与验收 | 进行中 |
-| Phase 3.5 | 端到端全链路联调：PRD → 技术设计 → OpenAPI → 代码生成 → CI | 待完成 |
-| Phase 4 | 稳定性加固、生产验证与推广 | 待完成 |
+| Phase 3.4b | `arcflow-api` skill 包在 NanoClaw 独立仓内的发布、接线与验收 | 独立仓持续跟进；本仓配套已完成 |
+| Phase 3.5 | 端到端全链路联调：PRD → 技术设计 → OpenAPI → 代码生成 → CI | 本仓已闭环，见 `2026-04-16` 验证报告 |
+| Phase 3.6 | CI 失败 → `bug_analysis` → `analysis_ready/failed` 回流闭环 | 本仓已闭环，见 `2026-04-17` 验证报告 |
+| Phase 4 | 稳定性、可观测性与生产验证 | 进行中 |
 
 ## 当前已实现能力
 
@@ -120,12 +122,18 @@ ArcFlow/
 - docs Git 仓库读写
 - 飞书通知与审批链接
 - GitHub Actions CI / 安全检查
+- CI 失败后的 `bug_analysis` 派生、回写与详情展示
+- Workflow Detail 中的 dispatch 状态、回调摘要与下一步动作提示
 
-### 今日新增
+### 最近里程碑
 
-- ArcFlow 侧 `arcflow-api` 交互配套已落地：`/api/arcflow/issues`、`/api/arcflow/requirements/drafts`
-- Web AiChat 已支持 `arcflow_card / arcflow_status` 结构化 artifact 渲染
-- 对应提交：`d9b1fd3 feat(arcflow): add gateway tools and chat artifact rendering`
+- `d9b1fd3 feat(arcflow): add gateway tools and chat artifact rendering`
+  - ArcFlow 侧 `arcflow-api` 交互配套落地：`/api/arcflow/issues`、`/api/arcflow/requirements/drafts`
+  - Web AiChat 支持 `arcflow_card / arcflow_status` 结构化 artifact 渲染
+- `1cc3cee feat: close phase 3.5 codegen and ci workflow loop (#120) (#124)`
+  - `code_gen` 列表摘要、详情页 subtasks / links、`/webhook/cicd` 与 `/webhook/ibuild` 统一回写已闭环
+- `ce543ef feat: close ci bug analysis backflow loop`
+  - `ci_failed` 派生 `bug_analysis`、回调 `analysis_ready / analysis_failed` 与前端摘要展示已闭环
 
 ## 运行方式
 
@@ -155,6 +163,13 @@ docker compose up -d
 - [setup/plane](setup/plane)
 - [setup/nanoclaw/README.md](setup/nanoclaw/README.md)
 - [setup/docs-repo/README.md](setup/docs-repo/README.md)
+
+关键验证记录：
+
+- [docs/superpowers/reports/2026-04-16-phase-3-5-verification.md](docs/superpowers/reports/2026-04-16-phase-3-5-verification.md)
+- [docs/superpowers/reports/2026-04-17-ci-bug-backflow-closure-verification.md](docs/superpowers/reports/2026-04-17-ci-bug-backflow-closure-verification.md)
+- [docs/superpowers/reports/2026-04-17-dispatch-callback-observability-verification.md](docs/superpowers/reports/2026-04-17-dispatch-callback-observability-verification.md)
+- [docs/superpowers/reports/2026-04-17-deployment-alignment-and-nanoclaw-stability-verification.md](docs/superpowers/reports/2026-04-17-deployment-alignment-and-nanoclaw-stability-verification.md)
 
 ## 历史说明
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,76 +1,143 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# ─── 配置 ────────────────────────────────────────────────────────
-SERVER="arcflow-server"
-DEPLOY_DIR="/data/project/arcflow"
-BRANCH="${1:-main}"
+SERVER="${ARCLOW_DEPLOY_SERVER:-arcflow-server}"
+ARCFLOW_DIR="${ARCFLOW_DEPLOY_DIR:-/data/project/arcflow}"
+NANOCLAW_DIR="${NANOCLAW_DEPLOY_DIR:-/data/project/nanoclaw}"
+NANOCLAW_PM2_APP="${NANOCLAW_PM2_APP:-arcflow-nanoclaw}"
 
-echo "=== ArcFlow 部署脚本 ==="
-echo "服务器: $SERVER"
-echo "部署目录: $DEPLOY_DIR"
-echo "分支: $BRANCH"
-echo ""
+usage() {
+  cat >&2 <<EOF
+用法:
+  $0 sync [branch]
+  $0 up [branch]
+  $0 status
+  $0 verify
+  $0 drift
+  $0 rollback <git-ref>
 
-# ─── 1. 同步代码 ─────────────────────────────────────────────────
-echo ">>> 同步代码到服务器..."
-ssh "$SERVER" "mkdir -p $DEPLOY_DIR"
+当前可信路径:
+  ArcFlow:  ${ARCFLOW_DIR}
+  NanoClaw: ${NANOCLAW_DIR}
+EOF
+}
 
-# 如果目标目录没有 git 仓库，先 clone
-ssh "$SERVER" "
-  if [ ! -d '$DEPLOY_DIR/.git' ]; then
-    git clone https://github.com/ssyamv/ArcFlow.git $DEPLOY_DIR
+log() {
+  printf '=== %s ===\n' "$*"
+}
+
+remote() {
+  ssh "$SERVER" "$1"
+}
+
+sync_repo() {
+  local branch="${1:-main}"
+  log "同步 ArcFlow 仓库到 ${SERVER}:${ARCFLOW_DIR} (${branch})"
+  remote "mkdir -p ${ARCFLOW_DIR}"
+  remote "
+    if [ ! -d '${ARCFLOW_DIR}/.git' ]; then
+      git clone https://github.com/ssyamv/ArcFlow.git ${ARCFLOW_DIR}
+    fi
+    cd ${ARCFLOW_DIR}
+    git fetch origin
+    git checkout ${branch}
+    git pull origin ${branch}
+  "
+}
+
+ensure_gateway_env() {
+  log "检查 Gateway 环境文件"
+  remote "
+    cd ${ARCFLOW_DIR}
+    if [ ! -f packages/gateway/.env ]; then
+      echo '⚠️  packages/gateway/.env 不存在，从模板创建...'
+      cp packages/gateway/.env.example packages/gateway/.env
+      echo '请编辑 packages/gateway/.env 填写实际配置'
+    fi
+  "
+}
+
+bring_up() {
+  log "构建并启动 ArcFlow 核心服务"
+  remote "
+    cd ${ARCFLOW_DIR}
+    docker compose build --no-cache
+    docker compose up -d
+  "
+}
+
+show_status() {
+  log "ArcFlow 容器状态"
+  remote "cd ${ARCFLOW_DIR} && docker compose ps"
+}
+
+verify_stack() {
+  log "验证当前生产拓扑"
+  printf 'ArcFlow 可信路径: %s\n' "$ARCFLOW_DIR"
+  printf 'NanoClaw 可信路径: %s\n' "$NANOCLAW_DIR"
+
+  remote "cd ${ARCFLOW_DIR} && docker compose ps"
+  remote "curl -sf http://127.0.0.1:3100/health"
+  remote "curl -I -sf http://127.0.0.1"
+  remote "pm2 describe ${NANOCLAW_PM2_APP}"
+}
+
+inspect_drift() {
+  log "检查 ArcFlow / NanoClaw 运行漂移"
+  remote "pm2 describe ${NANOCLAW_PM2_APP}"
+  remote "cd ${ARCFLOW_DIR} && git rev-parse --is-inside-work-tree"
+  remote "cd ${NANOCLAW_DIR} && git rev-parse --is-inside-work-tree || true"
+  remote "if [ -d /data/project/nanoclaw-fork ]; then cd /data/project/nanoclaw-fork && git rev-parse --is-inside-work-tree && git status --short; else echo 'nanoclaw-fork missing'; fi"
+}
+
+rollback_repo() {
+  local ref="${1:-}"
+  if [ -z "$ref" ]; then
+    usage
+    exit 1
   fi
-  cd $DEPLOY_DIR
-  git fetch origin
-  git checkout $BRANCH
-  git pull origin $BRANCH
-"
 
-# ─── 2. 检查 .env 文件 ──────────────────────────────────────────
-echo ""
-echo ">>> 检查环境配置..."
-ssh "$SERVER" "
-  cd $DEPLOY_DIR
-  if [ ! -f packages/gateway/.env ]; then
-    echo '⚠️  packages/gateway/.env 不存在，从模板创建...'
-    cp packages/gateway/.env.example packages/gateway/.env
-    echo '请编辑 packages/gateway/.env 填写实际配置'
-  fi
-"
+  log "回滚 ArcFlow 到 ${ref}"
+  remote "
+    cd ${ARCFLOW_DIR}
+    git fetch --all --tags
+    git checkout ${ref}
+    docker compose build --no-cache
+    docker compose up -d
+  "
+  verify_stack
+}
 
-# ─── 3. 构建并启动核心服务 ──────────────────────────────────────
-echo ""
-echo ">>> 构建并启动核心服务（Gateway + Web）..."
-ssh "$SERVER" "
-  cd $DEPLOY_DIR
-  docker compose build --no-cache
-  docker compose up -d
-"
+main() {
+  local command="${1:-up}"
 
-# ─── 4. 等待健康检查 ────────────────────────────────────────────
-echo ""
-echo ">>> 等待服务启动..."
-sleep 5
+  case "$command" in
+    sync)
+      sync_repo "${2:-main}"
+      ;;
+    up)
+      sync_repo "${2:-main}"
+      ensure_gateway_env
+      bring_up
+      verify_stack
+      ;;
+    status)
+      show_status
+      ;;
+    verify)
+      verify_stack
+      ;;
+    drift)
+      inspect_drift
+      ;;
+    rollback)
+      rollback_repo "${2:-}"
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+}
 
-ssh "$SERVER" "
-  echo '--- Gateway ---'
-  curl -sf http://localhost:3100/health && echo ' ✅' || echo ' ❌ Gateway 未就绪'
-
-  echo '--- Web ---'
-  curl -sf http://localhost:80 > /dev/null && echo '✅ Web 已就绪' || echo '❌ Web 未就绪'
-"
-
-# ─── 5. 显示状态 ────────────────────────────────────────────────
-echo ""
-echo ">>> 容器状态："
-ssh "$SERVER" "cd $DEPLOY_DIR && docker compose ps"
-
-echo ""
-echo "=== 部署完成 ==="
-echo "Gateway: http://172.29.230.21:3100"
-echo "Web:     http://172.29.230.21"
-echo ""
-echo "其他服务（按需启动）："
-echo "  Plane:  cd $DEPLOY_DIR/setup/plane && docker compose up -d"
-echo "  NanoClaw: pm2 restart arcflow-nanoclaw"
+main "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,8 @@
 #
 # 其他服务独立部署：
 # - Plane CE: setup/plane/docker-compose.yml
-# - Dify: setup/dify/docker-compose.yml
+# - NanoClaw: 独立仓库 + PM2，见 setup/nanoclaw/README.md
+# 历史上的 Dify / Weaviate / Wiki.js 已下线，不再作为当前部署依赖
 
 services:
   # ─── ArcFlow Gateway (Bun + Hono) ────────────────────────────────
@@ -42,6 +43,11 @@ services:
     depends_on:
       gateway:
         condition: service_healthy
+
+# 当前 compose 仅托管本仓两个核心服务：
+# - `gateway`
+# - `web`
+# 其余协作系统按各自目录或独立仓部署。
 
 volumes:
   gateway-data:

--- a/docs/AI研发运营一体化平台_技术架构方案.md
+++ b/docs/AI研发运营一体化平台_技术架构方案.md
@@ -1,7 +1,7 @@
 # AI 研发运营一体化平台 — 当前技术架构方案
 
-> 版本：v2.0  
-> 日期：2026-04-16  
+> 版本：v2.0
+> 日期：2026-04-17
 > 说明：本文件描述 ArcFlow 当前真实落地架构与阶段状态，替代早期 `Wiki.js + Dify + Weaviate` 方案作为当前参考。
 
 ---
@@ -174,7 +174,7 @@ docs 仓库是文档真实底座，不再依赖 Wiki 同步层。
 
 ### 5.1 已验证主链路
 
-当前已经真实跑通过的链路是：
+当前已经在本仓和联调环境中完成验证的链路是：
 
 ```text
 Web 对话 / 需求草稿
@@ -184,29 +184,36 @@ Web 对话 / 需求草稿
   → Plane webhook
   → 技术设计文档
   → OpenAPI
+  → code_gen
+  → CI webhook 回写
 ```
 
-这条链路已在 `2026-04-13` 的真实环境中验证通过，详见：
+对应验证与收口记录：
 
 - [superpowers/reports/2026-04-13-e2e-verification-report.md](superpowers/reports/2026-04-13-e2e-verification-report.md)
+- [superpowers/reports/2026-04-16-phase-3-5-verification.md](superpowers/reports/2026-04-16-phase-3-5-verification.md)
 
-### 5.2 正在补齐的后半段
+### 5.2 新近闭环能力
 
-当前仍在推进的后半段是：
+`2026-04-17` 前后补齐的闭环包括：
 
 ```text
-技术设计 / OpenAPI
-  → 代码生成
-  → Code Review
-  → CI
-  → Bug 回流
-  → 自动修复 / 再次验证
+CI 失败
+  → bug_analysis dispatch
+  → Gateway callback 持久化 analysis_ready / analysis_failed
+  → Workflow Detail 显示 bug_report_summary 与下一步动作
 ```
 
-也就是说，ArcFlow 当前的成熟度是：
+对应验证记录：
 
-- 前半段文档与任务链路已经成型
-- 后半段代码与交付链路正在从“设计完成”走向“可稳定复现”
+- [superpowers/reports/2026-04-17-ci-bug-backflow-closure-verification.md](superpowers/reports/2026-04-17-ci-bug-backflow-closure-verification.md)
+- [superpowers/reports/2026-04-17-dispatch-callback-observability-verification.md](superpowers/reports/2026-04-17-dispatch-callback-observability-verification.md)
+
+当前成熟度可以概括为：
+
+- 前半段文档与任务链路已经成型并完成真实环境联调
+- `tech_to_openapi -> code_gen -> CI -> bug_analysis` 的仓内闭环已经跑通
+- 当前重点已转向生产环境稳定性、部署对齐和跨仓库协作收口
 
 ---
 
@@ -214,7 +221,7 @@ Web 对话 / 需求草稿
 
 ### 6.1 已完成
 
-截至 `2026-04-16`，当前已完成的核心建设包括：
+截至 `2026-04-17`，当前已完成的核心建设包括：
 
 - docs 仓库与 CLAUDE.md 规范
 - Gateway 核心框架与测试基础
@@ -228,36 +235,41 @@ Web 对话 / 需求草稿
 - 鉴权透传与 memory snapshot
 - RAG 基础设施迁移到 Gateway sqlite-vec
 - 生产环境与部署拓扑梳理
+- Phase 3.5 代码生成与 CI 回写闭环
+- CI bug analysis 回流闭环
+- Workflow callback / dispatch 可观测性补强
 
 ### 6.2 进行中
 
 当前重点任务：
 
-- NanoClaw 仓内 `arcflow-api` skill 包发布与接线确认
-- NanoClaw 与 Gateway 的交互契约稳定化
-- 端到端链路 Phase 1 联调
-- 生产环境稳定性修复与部署文档对齐
+- NanoClaw 独立仓内 `arcflow-api` skill 包发布与接线确认
+- NanoClaw 与 Gateway 的跨仓契约维护
+- 生产环境稳定性修复、部署对齐与运维口径统一
+- 团队使用流程与操作规范沉淀
 
 ### 6.3 待完成
 
 后续阶段重点：
 
-- 代码生成链路全打通
-- Bug 回流自动修复闭环稳定化
-- 生产环境重复验证
+- 自动修复链路进一步稳定化
+- 更多生产场景重复验证
 - 团队推广与操作规范沉淀
 
 ### 6.4 今日进展补充
 
-`2026-04-16` 在 ArcFlow 仓库内已经完成一轮 `arcflow-api` 交互链路补齐，具体包括：
+最近对当前主线判断影响最大的进展是：
 
 - Gateway 新增 `/api/arcflow/issues`
 - Gateway 新增 `/api/arcflow/requirements/drafts`
 - Web AiChat 新增结构化 artifact 卡片渲染
+- `code_gen` 摘要、详情页 subtasks / links、CI webhook 回写完成闭环
+- `bug_analysis` 派生、回调摘要和前端展示完成闭环
 
 因此更准确的状态是：
 
-- **ArcFlow 侧交互契约与展示层已完成**
+- **ArcFlow 仓内主链路已完成到 CI / bug_analysis 回流这一层**
+- **NanoClaw 独立仓内 skill 包发布与生产编排仍需按独立仓状态跟进**
 - **NanoClaw 仓内 skill 包本体是否已同步发布，需要结合外部仓库继续确认**
 
 ---

--- a/docs/arcflow-nanoclaw-callback-contract.md
+++ b/docs/arcflow-nanoclaw-callback-contract.md
@@ -1,0 +1,188 @@
+# ArcFlow NanoClaw Callback Contract
+
+> 日期：2026-04-20
+> 范围：ArcFlow Gateway 与 NanoClaw 非交互 `arcflow-*` skills 之间的 `workflow callback` 协议
+> 说明：本文件是当前有效契约。若 skill 文档、历史 spec 或代码注释与本文冲突，以本文为准。
+
+## 1. 包装层
+
+所有回调都通过：
+
+```text
+POST {GATEWAY_URL}/api/workflow/callback
+```
+
+Header:
+
+- `X-System-Secret: {NANOCLAW_DISPATCH_SECRET}`
+- `Content-Type: application/json`
+
+请求体统一使用以下 envelope：
+
+```json
+{
+  "dispatch_id": "dispatch-123",
+  "skill": "arcflow-prd-to-tech",
+  "status": "success",
+  "output": {}
+}
+```
+
+失败回调：
+
+```json
+{
+  "dispatch_id": "dispatch-123",
+  "skill": "arcflow-prd-to-tech",
+  "status": "failed",
+  "error": "error message"
+}
+```
+
+规则：
+
+- `dispatch_id` 必填
+- `skill` 必填
+- `status` 只能是 `success` 或 `failed`
+- `success` 时必须使用 `output`
+- `failed` 时必须使用 `error`
+
+## 2. `arcflow-prd-to-tech`
+
+`status=success` 时，`output` 必须为：
+
+```json
+{
+  "tech_doc_path": "tech-design/2026-04/demo.md",
+  "content": "# Demo Tech Design",
+  "plane_issue_id": "ISSUE-1"
+}
+```
+
+字段要求：
+
+- `tech_doc_path`: 必填，相对路径，不能是绝对路径，不能包含越界路径
+- `content`: 必填，技术设计 Markdown 全文
+- `plane_issue_id`: 选填
+
+Gateway 行为：
+
+- 校验路径合法性
+- 将 `content` 写入 workspace docs repo 的 `tech_doc_path`
+
+## 3. `arcflow-tech-to-openapi`
+
+`status=success` 时，`output` 必须为：
+
+```json
+{
+  "openapi_path": "api/2026-04/demo.yaml",
+  "content": "openapi: 3.0.3",
+  "plane_issue_id": "ISSUE-1"
+}
+```
+
+字段要求：
+
+- `openapi_path`: 必填，相对路径，不能是绝对路径，不能包含越界路径
+- `content`: 必填，OpenAPI yaml 全文
+- `plane_issue_id`: 选填
+
+Gateway 行为：
+
+- 校验路径合法性
+- 将 `content` 写入 workspace docs repo 的 `openapi_path`
+- 如 execution context 存在，继续触发 `code_gen`
+
+## 4. `arcflow-bug-analysis`
+
+`status=success` 时，`output` 必须为：
+
+```json
+{
+  "summary": "编译失败",
+  "root_cause": "缺少依赖",
+  "suggested_fix": "补充依赖后重试",
+  "confidence": "high",
+  "next_action": "manual_handoff",
+  "plane_issue_id": "ISSUE-3"
+}
+```
+
+字段要求：
+
+- `summary`: 必填
+- `root_cause`: 必填
+- `suggested_fix`: 必填
+- `confidence`: 必填，只能是 `high`、`medium`、`low`
+- `next_action`: 必填，只能是 `auto_fix_candidate`、`manual_handoff`
+- `plane_issue_id`: 选填
+
+Gateway 行为：
+
+- 将结构化结果写入 `analysis_ready` 子任务摘要
+- 更新 workflow detail 的 `bug_report_summary`
+- 如 `plane_issue_id` 存在，则以 HTML 评论形式回写 Plane Issue
+
+## 5. 失败语义
+
+所有 `arcflow-*` 非交互 skill 在失败时统一回调：
+
+```json
+{
+  "dispatch_id": "dispatch-123",
+  "skill": "arcflow-tech-to-openapi",
+  "status": "failed",
+  "error": "error message"
+}
+```
+
+Gateway 行为：
+
+- 记录 dispatch 失败
+- 如有 source execution，则将 execution 置为失败
+- 不执行成功 side effect
+
+## 6. 大 payload 传输方式
+
+当 `output` 较大时，不应将完整 JSON 直接内联进 shell argv。
+
+推荐方式：
+
+1. 先把 payload 写入临时 JSON 文件
+2. 使用 `arcflow-api workflow callback ... @/path/to/payload.json`
+
+示例：
+
+```bash
+payload_file="$(mktemp)"
+trap 'rm -f "$payload_file"' EXIT
+
+jq -n \
+  --arg t "$tech_doc_path" \
+  --rawfile c "$tech_doc_path" \
+  --arg p "$plane_issue_id" \
+  '{tech_doc_path:$t, content:$c, plane_issue_id:$p}' > "$payload_file"
+
+arcflow-api workflow callback "$DISPATCH_ID" arcflow-prd-to-tech success "@$payload_file"
+```
+
+## 7. 兼容性原则
+
+- 当前契约是严格契约，不再接受旧版 `content-only` 或 `JSON-in-content` 的 success payload
+- 若未来需要改动字段，必须同步更新：
+  - ArcFlow Gateway parser 与测试
+  - NanoClaw CLI / skill 文档与测试
+  - 本契约文档
+
+## 8. 验证入口
+
+ArcFlow 侧：
+
+- `bun test packages/gateway/src/services/workflow-callback.test.ts`
+- `bun test packages/gateway/src/services/workflow-writeback.test.ts`
+- `bun test packages/gateway/src/services/plane.test.ts`
+
+NanoClaw 侧：
+
+- `npm test -- src/arcflow-api-cli.test.ts`

--- a/docs/documentation-status.md
+++ b/docs/documentation-status.md
@@ -24,11 +24,20 @@
 - `docs/superpowers/specs/2026-04-15-nanoclaw-hot-container-pool-design.md`
 - `docs/superpowers/specs/2026-04-16-deployment-alignment-and-nanoclaw-stability-design.md`
 - `docs/superpowers/specs/2026-04-16-end-to-end-arcflow-nanoclaw-phase1-design.md`
+- `docs/superpowers/specs/2026-04-17-ci-bug-backflow-closure-design.md`
+- `docs/superpowers/specs/2026-04-17-dispatch-callback-observability-design.md`
 
 补充说明：
 
 - `arcflow-api` 相关文档当前要区分 **ArcFlow 仓内配套实现** 与 **NanoClaw 仓内 skill 包本体** 两部分
-- 截至 `2026-04-16`，ArcFlow 仓内 Gateway 契约与 Web artifact 渲染已落地
+- 截至 `2026-04-17`，ArcFlow 仓内 Gateway 契约、Web artifact 渲染、Phase 3.5 闭环、CI bug 回流闭环均已落地
+
+以下验证报告可直接作为当前阶段事实依据：
+
+- `docs/superpowers/reports/2026-04-16-phase-3-5-verification.md`
+- `docs/superpowers/reports/2026-04-17-ci-bug-backflow-closure-verification.md`
+- `docs/superpowers/reports/2026-04-17-dispatch-callback-observability-verification.md`
+- `docs/superpowers/reports/2026-04-17-deployment-alignment-and-nanoclaw-stability-verification.md`
 
 ## 历史参考
 

--- a/docs/documentation-status.md
+++ b/docs/documentation-status.md
@@ -8,6 +8,8 @@
 
 - [README.md](../README.md)：项目总览、当前架构、当前开发状态
 - [AI研发运营一体化平台_技术架构方案.md](AI研发运营一体化平台_技术架构方案.md)：当前真实架构与阶段说明
+- [当前缺口清单_按优先级.md](当前缺口清单_按优先级.md)：当前阶段待完成事项与建议推进顺序
+- [arcflow-nanoclaw-callback-contract.md](arcflow-nanoclaw-callback-contract.md)：ArcFlow 与 NanoClaw 当前有效 callback 契约
 - [setup/docs-repo/README.md](../setup/docs-repo/README.md)：docs Git 仓库脚手架说明
 - [setup/docs-repo/CLAUDE.md](../setup/docs-repo/CLAUDE.md)：docs 仓库 AI 上下文模板
 - [setup/nanoclaw/README.md](../setup/nanoclaw/README.md)：NanoClaw 部署说明

--- a/docs/superpowers/plans/2026-04-20-p0-closure.md
+++ b/docs/superpowers/plans/2026-04-20-p0-closure.md
@@ -1,0 +1,889 @@
+# P0 Closure Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close all current P0 gaps by implementing real callback writeback in ArcFlow Gateway, aligning NanoClaw skill callback payloads with Gateway expectations, and locking the cross-repo callback contract with tests and docs.
+
+**Architecture:** ArcFlow remains the system of record for workflow state and side effects. NanoClaw continues to execute non-interactive skills and posts `success/failed` callbacks through the existing `arcflow-api workflow callback` CLI, but the internal `output` payload becomes the single shared contract. Gateway callback handling is extended with concrete docs Git writeback and Plane comment services, and both repos get tests that pin the contract.
+
+**Tech Stack:** Bun + Hono + bun:sqlite + simple-git in `ArcFlow`; Node/TypeScript + shell skill docs in `nanoclaw`; Bun test + Vitest where applicable.
+
+---
+
+## Task 1: Add failing ArcFlow tests for real callback side effects
+
+**Files:**
+
+- Modify: `packages/gateway/src/services/workflow-callback.test.ts`
+- Test: `packages/gateway/src/services/workflow-callback.test.ts`
+
+- [ ] **Step 1: Write failing tests for `arcflow-prd-to-tech`, `arcflow-tech-to-openapi`, and `arcflow-bug-analysis` success callbacks**
+
+Add tests that assert:
+
+```ts
+it("writes tech design content to docs on prd_to_tech success", async () => {
+  const writeTechDesign = vi.fn(async () => {});
+  const handler = createCallbackHandler({
+    writeTechDesign,
+    writeOpenApi: async () => {},
+    commentPlaneIssue: async () => {},
+    loadDispatch: async () => ({
+      id: "d1",
+      workspaceId: "7",
+      skill: "arcflow-prd-to-tech",
+      planeIssueId: "ISSUE-1",
+      status: "pending",
+      input: {},
+    }),
+    markDone: async () => true,
+  });
+
+  await handler.handle({
+    dispatch_id: "d1",
+    skill: "arcflow-prd-to-tech",
+    status: "success",
+    result: {
+      tech_doc_path: "tech-design/2026-04/demo.md",
+      content: "# Demo Tech Doc",
+      plane_issue_id: "ISSUE-1",
+    },
+  } as never);
+
+  expect(writeTechDesign).toHaveBeenCalledWith({
+    workspaceId: "7",
+    planeIssueId: "ISSUE-1",
+    relativePath: "tech-design/2026-04/demo.md",
+    content: "# Demo Tech Doc",
+  });
+});
+```
+
+and:
+
+```ts
+it("writes openapi content to docs on tech_to_openapi success", async () => {
+  const writeOpenApi = vi.fn(async () => {});
+  const triggerWorkflow = vi.fn(async () => 99);
+  const handler = createCallbackHandler({
+    writeTechDesign: async () => {},
+    writeOpenApi,
+    commentPlaneIssue: async () => {},
+    loadDispatch: async () => ({
+      id: "d2",
+      workspaceId: "7",
+      skill: "arcflow-tech-to-openapi",
+      planeIssueId: "ISSUE-1",
+      status: "pending",
+      input: {
+        execution_id: 12,
+        input_path: "tech-design/2026-04/demo.md",
+        target_repos: ["backend"],
+      },
+    }),
+    markDone: async () => true,
+    triggerWorkflow,
+  });
+
+  await handler.handle({
+    dispatch_id: "d2",
+    skill: "arcflow-tech-to-openapi",
+    status: "success",
+    result: {
+      openapi_path: "api/2026-04/demo.yaml",
+      content: "openapi: 3.0.3",
+      plane_issue_id: "ISSUE-1",
+    },
+  } as never);
+
+  expect(writeOpenApi).toHaveBeenCalledWith({
+    workspaceId: "7",
+    planeIssueId: "ISSUE-1",
+    relativePath: "api/2026-04/demo.yaml",
+    content: "openapi: 3.0.3",
+  });
+});
+```
+
+and:
+
+```ts
+it("comments structured bug analysis to plane on bug_analysis success", async () => {
+  const commentPlaneIssue = vi.fn(async () => {});
+  const handler = createCallbackHandler({
+    writeTechDesign: async () => {},
+    writeOpenApi: async () => {},
+    commentPlaneIssue,
+    loadDispatch: async () => ({
+      id: "d3",
+      workspaceId: "7",
+      skill: "arcflow-bug-analysis",
+      planeIssueId: "ISSUE-9",
+      status: "pending",
+      input: { execution_id: 8, target: "backend" },
+    }),
+    markDone: async () => true,
+    updateExecutionStatus: async () => {},
+  });
+
+  await handler.handle({
+    dispatch_id: "d3",
+    skill: "arcflow-bug-analysis",
+    status: "success",
+    result: {
+      summary: "unit tests fail in order flow",
+      root_cause: "missing null guard",
+      suggested_fix: "add null guard before mapping",
+      confidence: "high",
+      next_action: "auto_fix_candidate",
+      plane_issue_id: "ISSUE-9",
+    },
+  } as never);
+
+  expect(commentPlaneIssue).toHaveBeenCalled();
+});
+```
+
+- [ ] **Step 2: Write failing tests for invalid success payloads**
+
+Add tests that prove malformed success payloads now fail:
+
+```ts
+it("fails prd_to_tech callback when tech_doc_path is missing", async () => {
+  const markDone = vi.fn(async () => true);
+  const handler = createCallbackHandler({
+    writeTechDesign: async () => {},
+    writeOpenApi: async () => {},
+    commentPlaneIssue: async () => {},
+    loadDispatch: async () => ({
+      id: "d4",
+      workspaceId: "7",
+      skill: "arcflow-prd-to-tech",
+      status: "pending",
+      input: {},
+    }),
+    markDone,
+  });
+
+  await expect(
+    handler.handle({
+      dispatch_id: "d4",
+      skill: "arcflow-prd-to-tech",
+      status: "success",
+      result: { content: "# missing path" },
+    } as never),
+  ).rejects.toThrow("tech design callback payload is incomplete");
+});
+```
+
+Repeat the same pattern for missing `openapi_path` and for malformed bug-analysis structured fields.
+
+- [ ] **Step 3: Run the callback test file and verify RED**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-callback.test.ts
+```
+
+Expected: FAIL with missing `relativePath` handling and/or parser expectations for the new payload structure.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add packages/gateway/src/services/workflow-callback.test.ts
+git commit -m "test: cover callback writeback payload contract"
+```
+
+## Task 2: Implement ArcFlow callback payload parsing and formatter helpers
+
+**Files:**
+
+- Modify: `packages/gateway/src/services/workflow-callback.ts`
+- Test: `packages/gateway/src/services/workflow-callback.test.ts`
+
+- [ ] **Step 1: Add typed parsers for tech design and OpenAPI callback payloads**
+
+In `workflow-callback.ts`, add:
+
+```ts
+function parseTechDesignResult(result: unknown) {
+  if (!result || typeof result !== "object") {
+    throw new Error("tech design callback payload is incomplete");
+  }
+
+  const payload = result as Record<string, unknown>;
+  const relativePath = typeof payload.tech_doc_path === "string" ? payload.tech_doc_path : "";
+  const content = typeof payload.content === "string" ? payload.content : "";
+
+  if (!relativePath || !content) {
+    throw new Error("tech design callback payload is incomplete");
+  }
+
+  return {
+    relativePath,
+    content,
+    planeIssueId:
+      typeof payload.plane_issue_id === "string" ? payload.plane_issue_id : undefined,
+  };
+}
+
+function parseOpenApiResult(result: unknown) {
+  if (!result || typeof result !== "object") {
+    throw new Error("openapi callback payload is incomplete");
+  }
+
+  const payload = result as Record<string, unknown>;
+  const relativePath = typeof payload.openapi_path === "string" ? payload.openapi_path : "";
+  const content = typeof payload.content === "string" ? payload.content : "";
+
+  if (!relativePath || !content) {
+    throw new Error("openapi callback payload is incomplete");
+  }
+
+  return {
+    relativePath,
+    content,
+    planeIssueId:
+      typeof payload.plane_issue_id === "string" ? payload.plane_issue_id : undefined,
+  };
+}
+```
+
+- [ ] **Step 2: Add a Plane comment formatter for structured bug analysis**
+
+In `workflow-callback.ts`, add:
+
+```ts
+function formatBugAnalysisComment(report: {
+  summary: string;
+  root_cause: string;
+  suggested_fix: string;
+  confidence: "high" | "medium" | "low";
+  next_action: "auto_fix_candidate" | "manual_handoff";
+}) {
+  const nextActionText =
+    report.next_action === "auto_fix_candidate" ? "可进入自动修复" : "需人工接管";
+
+  return [
+    "## Bug Analysis",
+    "",
+    `- Summary: ${report.summary}`,
+    `- Root Cause: ${report.root_cause}`,
+    `- Suggested Fix: ${report.suggested_fix}`,
+    `- Confidence: ${report.confidence}`,
+    `- Next Action: ${nextActionText}`,
+  ].join("\n");
+}
+```
+
+- [ ] **Step 3: Replace success branches to use the new parsed payloads**
+
+Update the success branches:
+
+```ts
+} else if (skill === "arcflow-prd-to-tech") {
+  const result = parseTechDesignResult(p.result);
+  await deps.writeTechDesign({
+    workspaceId: rec.workspaceId,
+    planeIssueId: result.planeIssueId ?? piid,
+    relativePath: result.relativePath,
+    content: result.content,
+  });
+} else if (skill === "arcflow-tech-to-openapi") {
+  const result = parseOpenApiResult(p.result);
+  await deps.writeOpenApi({
+    workspaceId: rec.workspaceId,
+    planeIssueId: result.planeIssueId ?? piid,
+    relativePath: result.relativePath,
+    content: result.content,
+  });
+  // existing triggerWorkflow branch remains
+} else if (skill === "arcflow-bug-analysis") {
+  const report = parseBugAnalysisResult(p.result);
+  // existing markSubtaskProgress branch remains
+  if (piid) {
+    await deps.commentPlaneIssue({
+      planeIssueId: piid,
+      content: formatBugAnalysisComment(report),
+    });
+  }
+}
+```
+
+- [ ] **Step 4: Run the callback test file and verify GREEN**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-callback.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit the parser and formatter changes**
+
+```bash
+git add packages/gateway/src/services/workflow-callback.ts packages/gateway/src/services/workflow-callback.test.ts
+git commit -m "feat: parse structured callback payloads"
+```
+
+## Task 3: Add failing ArcFlow tests for docs Git writeback and Plane comments
+
+**Files:**
+
+- Create: `packages/gateway/src/services/workflow-writeback.test.ts`
+- Modify: `packages/gateway/src/services/plane.test.ts`
+- Test: `packages/gateway/src/services/workflow-writeback.test.ts`
+- Test: `packages/gateway/src/services/plane.test.ts`
+
+- [ ] **Step 1: Write a failing docs writeback service test**
+
+Create `workflow-writeback.test.ts` with:
+
+```ts
+import { describe, expect, it, vi } from "bun:test";
+import { createWorkflowWritebackService } from "./workflow-writeback";
+
+describe("workflow writeback service", () => {
+  it("writes generated docs into the workspace docs repo", async () => {
+    const registerRepoUrl = vi.fn();
+    const ensureRepo = vi.fn(async () => {});
+    const writeAndPush = vi.fn(async () => {});
+    const getWorkspace = vi.fn(() => ({
+      id: 7,
+      slug: "demo",
+      git_repos: JSON.stringify({ docs: "git@github.com:ssyamv/demo-docs.git" }),
+    }));
+
+    const service = createWorkflowWritebackService({
+      getWorkspace,
+      registerRepoUrl,
+      ensureRepo,
+      writeAndPush,
+    });
+
+    await service.writeGeneratedDoc({
+      workspaceId: "7",
+      relativePath: "tech-design/2026-04/demo.md",
+      content: "# Demo",
+      commitMessage: "docs: add tech design for ISSUE-1",
+    });
+
+    expect(registerRepoUrl).toHaveBeenCalledWith(
+      "ws-7-docs",
+      "git@github.com:ssyamv/demo-docs.git",
+    );
+    expect(writeAndPush).toHaveBeenCalledWith(
+      "ws-7-docs",
+      "tech-design/2026-04/demo.md",
+      "# Demo",
+      "docs: add tech design for ISSUE-1",
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Write a failing Plane comment service test**
+
+In `plane.test.ts`, add:
+
+```ts
+it("createIssueComment posts HTML comment to plane", async () => {
+  const mockFetch = vi.fn(async () => ({
+    ok: true,
+    json: async () => ({ id: "comment-1" }),
+  }));
+
+  await createIssueComment(
+    {
+      baseUrl: "https://plane.example.com",
+      apiKey: "token",
+      fetch: mockFetch as never,
+    },
+    "ISSUE-1",
+    "<p>analysis</p>",
+  );
+
+  expect(mockFetch).toHaveBeenCalledWith(
+    "https://plane.example.com/api/v1/issues/ISSUE-1/comments/",
+    expect.objectContaining({
+      method: "POST",
+    }),
+  );
+});
+```
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts
+```
+
+Expected: FAIL because `workflow-writeback.ts` and `createIssueComment` do not exist yet.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts
+git commit -m "test: cover docs writeback and plane comments"
+```
+
+## Task 4: Implement ArcFlow docs writeback and Plane comment services
+
+**Files:**
+
+- Create: `packages/gateway/src/services/workflow-writeback.ts`
+- Modify: `packages/gateway/src/services/plane.ts`
+- Test: `packages/gateway/src/services/workflow-writeback.test.ts`
+- Test: `packages/gateway/src/services/plane.test.ts`
+
+- [ ] **Step 1: Implement `createWorkflowWritebackService`**
+
+Create `workflow-writeback.ts`:
+
+```ts
+import { getWorkspace } from "../db/queries";
+import { ensureRepo, registerRepoUrl, writeAndPush } from "./git";
+
+function parseRepos(raw: string) {
+  try {
+    return JSON.parse(raw || "{}") as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+export function createWorkflowWritebackService(deps = {
+  getWorkspace,
+  registerRepoUrl,
+  ensureRepo,
+  writeAndPush,
+}) {
+  return {
+    async writeGeneratedDoc(input: {
+      workspaceId: string;
+      relativePath: string;
+      content: string;
+      commitMessage: string;
+    }) {
+      const workspace = deps.getWorkspace(Number(input.workspaceId));
+      if (!workspace) throw new Error(`workspace ${input.workspaceId} not found`);
+
+      const repos = parseRepos(workspace.git_repos);
+      if (!repos.docs) throw new Error(`workspace ${input.workspaceId} docs repo not configured`);
+
+      const repoName = `ws-${workspace.id}-docs`;
+      deps.registerRepoUrl(repoName, repos.docs);
+      await deps.ensureRepo(repoName);
+      await deps.writeAndPush(repoName, input.relativePath, input.content, input.commitMessage);
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Implement `createIssueComment` in `plane.ts`**
+
+Add to `plane.ts`:
+
+```ts
+export async function createIssueComment(
+  deps: {
+    baseUrl?: string;
+    apiKey?: string;
+    fetch?: typeof globalThis.fetch;
+  },
+  issueId: string,
+  commentHtml: string,
+) {
+  const baseUrl = deps.baseUrl ?? process.env.PLANE_BASE_URL ?? "";
+  const apiKey = deps.apiKey ?? process.env.PLANE_API_TOKEN ?? "";
+  const fetchImpl = deps.fetch ?? fetch;
+
+  const response = await fetchImpl(`${baseUrl.replace(/\/+$/, "")}/api/v1/issues/${issueId}/comments/`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-API-Key": apiKey,
+    },
+    body: JSON.stringify({
+      comment_html: commentHtml,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Plane createIssueComment failed: ${response.status}`);
+  }
+
+  return response.json();
+}
+```
+
+- [ ] **Step 3: Run the new service tests and verify GREEN**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the service implementations**
+
+```bash
+git add packages/gateway/src/services/workflow-writeback.ts packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.ts packages/gateway/src/services/plane.test.ts
+git commit -m "feat: add workflow docs writeback and plane comments"
+```
+
+## Task 5: Wire ArcFlow callback side effects into the real services
+
+**Files:**
+
+- Modify: `packages/gateway/src/index.ts`
+- Modify: `packages/gateway/src/services/workflow-callback.ts`
+- Test: `packages/gateway/src/services/workflow-callback.test.ts`
+- Test: `packages/gateway/src/index.test.ts`
+
+- [ ] **Step 1: Update callback dependency types to accept `relativePath`**
+
+In `workflow-callback.ts`, change dependency shapes:
+
+```ts
+writeTechDesign: (x: {
+  workspaceId: string;
+  planeIssueId?: string;
+  relativePath: string;
+  content: string;
+}) => Promise<void>;
+writeOpenApi: (x: {
+  workspaceId: string;
+  planeIssueId?: string;
+  relativePath: string;
+  content: string;
+}) => Promise<void>;
+```
+
+- [ ] **Step 2: Wire `index.ts` to real services**
+
+In `index.ts`:
+
+```ts
+import { createWorkflowWritebackService } from "./services/workflow-writeback";
+import { createIssueComment } from "./services/plane";
+
+const writebackService = createWorkflowWritebackService();
+
+const callbackHandler = createCallbackHandler({
+  writeTechDesign: async ({ workspaceId, planeIssueId, relativePath, content }) => {
+    await writebackService.writeGeneratedDoc({
+      workspaceId,
+      relativePath,
+      content,
+      commitMessage: `docs: add tech design for ${planeIssueId ?? "callback output"}`,
+    });
+  },
+  writeOpenApi: async ({ workspaceId, planeIssueId, relativePath, content }) => {
+    await writebackService.writeGeneratedDoc({
+      workspaceId,
+      relativePath,
+      content,
+      commitMessage: `docs: add openapi for ${planeIssueId ?? "callback output"}`,
+    });
+  },
+  commentPlaneIssue: async ({ planeIssueId, content }) => {
+    await createIssueComment({}, planeIssueId, content.replace(/\n/g, "<br />"));
+  },
+  // existing deps unchanged
+});
+```
+
+- [ ] **Step 3: Run focused callback and app routing tests**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-callback.test.ts packages/gateway/src/index.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Commit the callback wiring**
+
+```bash
+git add packages/gateway/src/index.ts packages/gateway/src/services/workflow-callback.ts packages/gateway/src/services/workflow-callback.test.ts packages/gateway/src/index.test.ts
+git commit -m "feat: wire callback side effects to real services"
+```
+
+## Task 6: Add failing NanoClaw tests for callback payload alignment
+
+**Files:**
+
+- Modify: `/Users/chenqi/code/nanoclaw/src/arcflow-api-cli.test.ts`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-prd-to-tech/SKILL.md`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-tech-to-openapi/SKILL.md`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-bug-analysis/SKILL.md`
+- Test: `/Users/chenqi/code/nanoclaw/src/arcflow-api-cli.test.ts`
+
+- [ ] **Step 1: Add failing CLI tests for structured success payloads**
+
+In `arcflow-api-cli.test.ts`, add tests that assert:
+
+```ts
+it("posts tech design success payload with content and path", async () => {
+  // invoke workflow callback command
+  // expect outgoing body.output.tech_doc_path and body.output.content
+});
+
+it("posts openapi success payload with content and path", async () => {
+  // expect outgoing body.output.openapi_path and body.output.content
+});
+
+it("posts bug analysis success payload with structured fields", async () => {
+  // expect outgoing body.output.summary/root_cause/suggested_fix/confidence/next_action
+});
+```
+
+Use the existing CLI callback test style in the NanoClaw repo; only add new assertions for the `output` object shape.
+
+- [ ] **Step 2: Update skill docs first so tests reflect the desired contract**
+
+Change the skill examples to the new payloads:
+
+```bash
+arcflow-api workflow callback "$DISPATCH_ID" arcflow-prd-to-tech success \
+  "$(jq -n --arg t "$TECH_DOC_PATH" --arg c "$TECH_DOC_CONTENT" --arg p "$PLANE_ISSUE_ID" \
+     '{tech_doc_path:$t, content:$c, plane_issue_id:$p}')"
+```
+
+```bash
+arcflow-api workflow callback "$DISPATCH_ID" arcflow-tech-to-openapi success \
+  "$(jq -n --arg o "$OPENAPI_PATH" --arg c "$OPENAPI_CONTENT" --arg p "$PLANE_ISSUE_ID" \
+     '{openapi_path:$o, content:$c, plane_issue_id:$p}')"
+```
+
+```bash
+arcflow-api workflow callback "$DISPATCH_ID" arcflow-bug-analysis success \
+  "$(jq -n \
+     --arg summary "$SUMMARY" \
+     --arg root "$ROOT_CAUSE" \
+     --arg fix "$SUGGESTED_FIX" \
+     --arg confidence "$CONFIDENCE" \
+     --arg next "$NEXT_ACTION" \
+     --arg p "$PLANE_ISSUE_ID" \
+     '{summary:$summary, root_cause:$root, suggested_fix:$fix, confidence:$confidence, next_action:$next, plane_issue_id:$p}')"
+```
+
+- [ ] **Step 3: Run the NanoClaw CLI test file and verify RED**
+
+Run:
+
+```bash
+cd /Users/chenqi/code/nanoclaw && npm test -- src/arcflow-api-cli.test.ts
+```
+
+Expected: FAIL until the CLI tests and/or fixtures match the new contract.
+
+- [ ] **Step 4: Commit the failing NanoClaw tests/docs**
+
+```bash
+cd /Users/chenqi/code/nanoclaw && git add src/arcflow-api-cli.test.ts container/skills/arcflow-prd-to-tech/SKILL.md container/skills/arcflow-tech-to-openapi/SKILL.md container/skills/arcflow-bug-analysis/SKILL.md && git commit -m "test: pin arcflow callback payload shapes"
+```
+
+## Task 7: Make NanoClaw callback contract tests pass
+
+**Files:**
+
+- Modify: `/Users/chenqi/code/nanoclaw/src/arcflow-api-cli.test.ts`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-prd-to-tech/SKILL.md`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-tech-to-openapi/SKILL.md`
+- Modify: `/Users/chenqi/code/nanoclaw/container/skills/arcflow-bug-analysis/SKILL.md`
+- Test: `/Users/chenqi/code/nanoclaw/src/arcflow-api-cli.test.ts`
+
+- [ ] **Step 1: Align NanoClaw callback payload examples and fixtures to the ArcFlow contract**
+
+Update any CLI fixtures or test helper payloads so the callback command posts:
+
+```json
+{
+  "dispatch_id": "dispatch-1",
+  "skill": "arcflow-prd-to-tech",
+  "status": "success",
+  "output": {
+    "tech_doc_path": "tech-design/2026-04/demo.md",
+    "content": "# Demo Tech Doc",
+    "plane_issue_id": "ISSUE-1"
+  }
+}
+```
+
+and:
+
+```json
+{
+  "dispatch_id": "dispatch-2",
+  "skill": "arcflow-tech-to-openapi",
+  "status": "success",
+  "output": {
+    "openapi_path": "api/2026-04/demo.yaml",
+    "content": "openapi: 3.0.3",
+    "plane_issue_id": "ISSUE-1"
+  }
+}
+```
+
+and:
+
+```json
+{
+  "dispatch_id": "dispatch-3",
+  "skill": "arcflow-bug-analysis",
+  "status": "success",
+  "output": {
+    "summary": "unit tests fail in order flow",
+    "root_cause": "missing null guard",
+    "suggested_fix": "add null guard before mapping",
+    "confidence": "high",
+    "next_action": "auto_fix_candidate",
+    "plane_issue_id": "ISSUE-9"
+  }
+}
+```
+
+- [ ] **Step 2: Run the NanoClaw CLI tests and verify GREEN**
+
+Run:
+
+```bash
+cd /Users/chenqi/code/nanoclaw && npm test -- src/arcflow-api-cli.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 3: Commit the NanoClaw contract alignment**
+
+```bash
+cd /Users/chenqi/code/nanoclaw && git add src/arcflow-api-cli.test.ts container/skills/arcflow-prd-to-tech/SKILL.md container/skills/arcflow-tech-to-openapi/SKILL.md container/skills/arcflow-bug-analysis/SKILL.md && git commit -m "feat: align arcflow skill callback contract"
+```
+
+## Task 8: Write and link the formal callback contract doc
+
+**Files:**
+
+- Create: `docs/arcflow-nanoclaw-callback-contract.md`
+- Modify: `docs/documentation-status.md`
+- Modify: `docs/当前缺口清单_按优先级.md`
+- Test: n/a
+
+- [ ] **Step 1: Write the contract doc**
+
+Create `docs/arcflow-nanoclaw-callback-contract.md` with sections:
+
+```md
+# ArcFlow NanoClaw Callback Contract
+
+## Skills
+- arcflow-prd-to-tech
+- arcflow-tech-to-openapi
+- arcflow-bug-analysis
+
+## Envelope
+- dispatch_id
+- skill
+- status
+- output (success only)
+- error (failed only)
+
+## Success Payloads
+...
+
+## Failure Semantics
+...
+```
+
+Include the exact payload shapes from Tasks 2 and 7.
+
+- [ ] **Step 2: Link the contract doc into current effective docs**
+
+Update `documentation-status.md` current-effective section and add a short note in `当前缺口清单_按优先级.md` that P0-3 is tracked by this contract doc.
+
+- [ ] **Step 3: Commit the contract documentation**
+
+```bash
+git add docs/arcflow-nanoclaw-callback-contract.md docs/documentation-status.md docs/当前缺口清单_按优先级.md
+git commit -m "docs: add arcflow nanoclaw callback contract"
+```
+
+## Task 9: Run full verification and close the backlog items
+
+**Files:**
+
+- Modify: `docs/当前缺口清单_按优先级.md`
+- Test: `packages/gateway/src/services/workflow-callback.test.ts`
+- Test: `packages/gateway/src/services/workflow-writeback.test.ts`
+- Test: `packages/gateway/src/services/plane.test.ts`
+- Test: `/Users/chenqi/code/nanoclaw/src/arcflow-api-cli.test.ts`
+
+- [ ] **Step 1: Run ArcFlow focused verification**
+
+Run:
+
+```bash
+bun test packages/gateway/src/services/workflow-callback.test.ts packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 2: Run ArcFlow full repo verification**
+
+Run:
+
+```bash
+bun run test
+bun run --cwd packages/web build
+```
+
+Expected:
+
+```text
+all tests pass
+vite build succeeds
+```
+
+- [ ] **Step 3: Run NanoClaw verification**
+
+Run:
+
+```bash
+cd /Users/chenqi/code/nanoclaw && npm test -- src/arcflow-api-cli.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 4: Mark P0 items complete in the backlog doc**
+
+Update `docs/当前缺口清单_按优先级.md`:
+
+```md
+### [x] P0-1 ...
+完成日期：2026-04-20
+验证方式：ArcFlow callback tests + NanoClaw CLI callback tests + local full test/build
+备注：skill payload 与 Gateway callback parser 已收口
+```
+
+Repeat for `P0-2` and `P0-3`.
+
+- [ ] **Step 5: Commit verification and backlog closure**
+
+```bash
+git add docs/当前缺口清单_按优先级.md
+git commit -m "docs: mark p0 closure complete"
+```
+
+## Self-Review
+
+- Spec coverage: this plan covers the three approved P0 items only: real writeback, NanoClaw contract alignment, and cross-repo contract documentation.
+- Placeholder scan: no `TODO` / `TBD` placeholders remain in the task steps.
+- Type consistency: the plan consistently uses `relativePath`, `content`, `tech_doc_path`, `openapi_path`, `summary`, `root_cause`, `suggested_fix`, `confidence`, and `next_action` across ArcFlow and NanoClaw tasks.

--- a/docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md
+++ b/docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md
@@ -1,0 +1,178 @@
+# P1 Deployment Alignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the first minimal slice of P1-4 by making `deploy.sh` the standard production operations entrypoint and documenting the single trusted deployment paths.
+
+**Architecture:** Keep the current deployment topology, but make the root script express the current production truth explicitly through stable subcommands. Add a runbook for operators and lock the script contract with focused Bun tests that stub `ssh` rather than touching the real server.
+
+**Tech Stack:** Bash, Bun test, Markdown
+
+---
+
+## Task 1: Add failing tests for the deployment entrypoint contract
+
+**Files:**
+
+- Create: `setup/deploy.test.ts`
+- Modify: `deploy.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `setup/deploy.test.ts` with coverage for `status`, `verify`, and `rollback`:
+
+```ts
+import { afterEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT = join(process.cwd(), "deploy.sh");
+
+function makeFakeSshDir() {
+  const dir = mkdtempSync(join(tmpdir(), "arcflow-deploy-test-"));
+  const logPath = join(dir, "ssh.log");
+  const sshPath = join(dir, "ssh");
+  writeFileSync(
+    sshPath,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${logPath}"
+if [[ "$*" == *"curl -sf http://127.0.0.1:3100/health"* ]]; then
+  printf '{"status":"ok"}'
+fi
+`,
+  );
+  chmodSync(sshPath, 0o755);
+  return { dir, logPath };
+}
+
+async function runDeploy(args: string[]) {
+  const fake = makeFakeSshDir();
+  const proc = Bun.spawn(["bash", SCRIPT, ...args], {
+    cwd: process.cwd(),
+    env: { ...process.env, PATH: `${fake.dir}:${process.env.PATH ?? ""}` },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  const sshLog = readFileSync(fake.logPath, "utf8");
+  rmSync(fake.dir, { recursive: true, force: true });
+  return { exitCode, stdout, stderr, sshLog };
+}
+
+describe("deploy.sh", () => {
+  it("runs status against the trusted ArcFlow directory", async () => {
+    const result = await runDeploy(["status"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.sshLog).toContain("cd /data/project/arcflow && docker compose ps");
+  });
+
+  it("runs verify with gateway, web, and nanoclaw checks", async () => {
+    const result = await runDeploy(["verify"]);
+    expect(result.exitCode).toBe(0);
+    expect(result.sshLog).toContain("curl -sf http://127.0.0.1:3100/health");
+    expect(result.sshLog).toContain("curl -I -sf http://127.0.0.1");
+    expect(result.sshLog).toContain("pm2 describe arcflow-nanoclaw");
+  });
+
+  it("fails rollback without a git ref", async () => {
+    const result = await runDeploy(["rollback"]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("用法");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test setup/deploy.test.ts`
+Expected: FAIL because `deploy.sh` does not yet support the tested `status / verify / rollback` contract.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Update `deploy.sh` to:
+
+- parse subcommands instead of treating the first argument as only branch
+- keep `sync` and `up` for the existing deployment flow
+- add `status`, `verify`, and `rollback <git-ref>`
+- standardize trusted directories as shell constants
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test setup/deploy.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy.sh setup/deploy.test.ts
+git commit -m "feat: standardize production deploy entrypoint"
+```
+
+## Task 2: Add the current production runbook and backlog update
+
+**Files:**
+
+- Create: `setup/production-runbook.md`
+- Modify: `docs/当前缺口清单_按优先级.md`
+
+- [ ] **Step 1: Write the documentation update**
+
+Create `setup/production-runbook.md` with these sections:
+
+- 当前可信路径
+- 日常更新
+- 回滚
+- 验证
+- 漂移说明
+
+It must state:
+
+- ArcFlow path: `/data/project/arcflow`
+- NanoClaw path: `/data/project/nanoclaw`
+- historical drift path: `/data/project/nanoclaw-fork`
+
+- [ ] **Step 2: Update the backlog item**
+
+In `docs/当前缺口清单_按优先级.md`, update `P1-4` to record that the first deployment-alignment slice is complete, with date and verification command.
+
+- [ ] **Step 3: Run focused doc verification**
+
+Run: `bunx markdownlint-cli2 "setup/production-runbook.md" "docs/当前缺口清单_按优先级.md" "docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md"`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add setup/production-runbook.md docs/当前缺口清单_按优先级.md docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md
+git commit -m "docs: add production deployment runbook"
+```
+
+## Task 3: Run final verification for this slice
+
+**Files:**
+
+- Verify only: `deploy.sh`, `setup/deploy.test.ts`, `setup/production-runbook.md`, `docs/当前缺口清单_按优先级.md`
+
+- [ ] **Step 1: Run deploy entrypoint tests**
+
+Run: `bun test setup/deploy.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Run markdown verification**
+
+Run: `bunx markdownlint-cli2 "setup/production-runbook.md" "docs/当前缺口清单_按优先级.md" "docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md" "docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md"`
+Expected: PASS
+
+- [ ] **Step 3: Report exact status**
+
+Record the commands and results in the final response. Do not claim completion without those fresh outputs.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy.sh setup/deploy.test.ts setup/production-runbook.md docs/当前缺口清单_按优先级.md docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md
+git commit -m "chore: close first p1 deployment alignment slice"
+```

--- a/docs/superpowers/plans/2026-04-20-p1-runtime-drift-check.md
+++ b/docs/superpowers/plans/2026-04-20-p1-runtime-drift-check.md
@@ -1,0 +1,73 @@
+# P1 Runtime Drift Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a safe drift inspection entrypoint so P1-4 can expose real server drift before any risky cleanup on NanoClaw production paths.
+
+**Architecture:** Extend the existing root deployment script with a read-only `drift` subcommand. Keep it diagnostic-only: inspect PM2, ArcFlow git state, NanoClaw runtime git state, and the historical `nanoclaw-fork` repo without modifying anything. Update the runbook and backlog to treat server cleanup as a separate follow-up.
+
+**Tech Stack:** Bash, Bun test, Markdown
+
+---
+
+## Task 1: Add a failing test for drift inspection
+
+**Files:**
+
+- Modify: `setup/deploy.test.ts`
+- Modify: `deploy.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Add a `drift` test that expects `deploy.sh drift` to call:
+
+- `pm2 describe arcflow-nanoclaw`
+- `cd /data/project/arcflow && git rev-parse --is-inside-work-tree`
+- `cd /data/project/nanoclaw && git rev-parse --is-inside-work-tree`
+- `cd /data/project/nanoclaw-fork && git status --short`
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test setup/deploy.test.ts`
+Expected: FAIL because `deploy.sh` does not yet support `drift`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add a read-only `drift` subcommand to `deploy.sh`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test setup/deploy.test.ts`
+Expected: PASS
+
+## Task 2: Update the runbook and backlog with drift inspection
+
+**Files:**
+
+- Modify: `setup/production-runbook.md`
+- Modify: `docs/当前缺口清单_按优先级.md`
+- Add: `docs/superpowers/specs/2026-04-20-p1-runtime-drift-check-design.md`
+- Add: `docs/superpowers/plans/2026-04-20-p1-runtime-drift-check.md`
+
+- [ ] **Step 1: Document the new drift command**
+
+Add `./deploy.sh drift` to the runbook and describe the currently known server facts:
+
+- `/data/project/nanoclaw` is the active runtime path
+- `/data/project/nanoclaw` is not a git repo
+- `/data/project/nanoclaw-fork` still exists as a dirty historical git checkout
+
+- [ ] **Step 2: Update the backlog item**
+
+Record that the second P1-4 slice adds a safe drift inspection entrypoint, but the actual server cleanup is still pending because the fork checkout is dirty.
+
+- [ ] **Step 3: Run verification**
+
+Run:
+
+```bash
+bun test setup/deploy.test.ts
+bunx markdownlint-cli2 "setup/production-runbook.md" "docs/当前缺口清单_按优先级.md" "docs/superpowers/specs/2026-04-20-p1-runtime-drift-check-design.md" "docs/superpowers/plans/2026-04-20-p1-runtime-drift-check.md"
+```
+
+Expected: PASS

--- a/docs/superpowers/specs/2026-04-20-p0-closure-design.md
+++ b/docs/superpowers/specs/2026-04-20-p0-closure-design.md
@@ -1,0 +1,279 @@
+# P0 Closure Design
+
+## 1. 背景
+
+截至 `2026-04-20`，ArcFlow 本仓已经完成到 `Phase 3.6`，主链路
+`PRD -> 技术设计 -> OpenAPI -> code_gen -> CI -> bug_analysis` 的仓内闭环已被验证。
+
+当前仍阻塞进入稳定交付状态的 P0 缺口集中在三处：
+
+1. `workflow callback` 的 docs / Plane 写回仍是 Gateway 主入口中的占位实现
+2. `prd_to_tech`、`tech_to_openapi`、`bug_analysis` 仍依赖 NanoClaw 独立仓 skill 包的真实 callback 契约
+3. ArcFlow 与 NanoClaw 之间缺少被代码和文档共同约束的稳定契约，存在字段漂移风险
+
+本设计只解决这三项，不扩展到自动修复链路、Phase 4 其他稳定性工作或新的业务流程。
+
+## 2. 目标
+
+完成本次 P0 收口后，系统应满足：
+
+- `arcflow-prd-to-tech` 成功回调后，技术设计文档被真实写入 docs repo
+- `arcflow-tech-to-openapi` 成功回调后，OpenAPI 文档被真实写入 docs repo
+- `arcflow-bug-analysis` 成功回调后，Bug 分析结果被真实评论回 Plane Issue
+- ArcFlow 与 NanoClaw 使用一套明确、可测试、可追溯的 callback 契约
+- 本地测试可以覆盖成功、失败、字段错误、跨仓契约兼容性
+
+## 3. 非目标
+
+- 不在本次实现中引入“自动修复”执行链路
+- 不重构现有 workflow model 或 dispatch model
+- 不将 Git webhook 空实现纳入本次 P0
+- 不处理历史 `Wiki.js / Dify / Weaviate` 相关路径
+
+## 4. 方案对比
+
+### 方案 A：只在 ArcFlow 侧补正式写回，NanoClaw 保持现状
+
+优点：
+
+- ArcFlow 改动少，落地快
+
+缺点：
+
+- skill 输出格式仍然主要靠约定而不是双侧约束
+- 未来 NanoClaw skill 文档或 CLI 改动后，仍可能出现联调回归
+
+### 方案 B：ArcFlow 和 NanoClaw 同步收口 callback 契约
+
+优点：
+
+- 这是唯一能真正关闭 P0 的方案
+- docs / Plane 写回与 skill 回调字段一起被测试锁定
+- 后续变更时更容易发现契约漂移
+
+缺点：
+
+- 需要跨两个仓库改动
+- 测试和文档都要同步维护
+
+### 方案 C：先补契约文档，不改实现
+
+优点：
+
+- 成本最低
+
+缺点：
+
+- 无法解决当前主入口仍是占位实现的问题
+- 不能算 P0 完成
+
+**推荐方案：B。**  
+P0 的核心不是“写文档”，而是把主链路从“本仓闭环”推进到“跨仓可稳定落地”。这只能通过 ArcFlow 与 NanoClaw 同步收口来完成。
+
+## 5. 总体设计
+
+### 5.1 ArcFlow 侧
+
+在 `packages/gateway` 中新增正式 callback side effects：
+
+- 技术设计文档写回 docs repo
+- OpenAPI 文档写回 docs repo
+- Bug 分析结果评论回 Plane Issue
+
+这些 side effects 通过 `createCallbackHandler` 的依赖注入接入，替换当前 `index.ts` 中的 `console.log` 占位实现。
+
+### 5.2 NanoClaw 侧
+
+NanoClaw 继续通过 `arcflow-api workflow callback` 调用 Gateway，但 skill 和 CLI 需要与 ArcFlow 正式字段保持一致：
+
+- `arcflow-prd-to-tech` 输出 `tech_doc_path`
+- `arcflow-tech-to-openapi` 输出 `openapi_path`
+- `arcflow-bug-analysis` 输出结构化分析字段，而不是仅交付一段 Markdown
+
+当前 `arcflow-bug-analysis` skill 文档仍描述返回 `bug_report / severity / fix_attempted`，而 ArcFlow callback 代码实际要求的是 `summary / root_cause / suggested_fix / confidence / next_action` 结构。这是必须消除的契约冲突。
+
+### 5.3 契约文档
+
+增加一份面向当前主线的 callback 契约文档，明确：
+
+- 各 skill 的 dispatch input
+- 各 skill 的 success payload
+- failed payload 约定
+- Gateway side effect 语义
+- 字段校验与失败策略
+
+这份文档是未来变更的唯一当前参考，不再依赖分散在 skill 文档和 callback 解析代码中的隐式约定。
+
+## 6. 组件设计
+
+### 6.1 Docs writeback service
+
+在 ArcFlow Gateway 中新增一个专门的 docs writeback service，职责是：
+
+- 根据 `workspaceId` 解析 docs repo 名称
+- 确保 repo 已注册且存在本地 checkout
+- 将生成结果写入指定相对路径
+- 提交并推送到 docs repo
+
+接口建议保持简单：
+
+```ts
+writeGeneratedDoc({
+  workspaceId,
+  relativePath,
+  content,
+}): Promise<void>
+```
+
+不在本次实现中增加复杂 frontmatter 生成逻辑。当前 skill 已生成完整文档内容，Gateway 只负责可靠写回。
+
+### 6.2 Plane comment service
+
+在 ArcFlow Gateway 中补一个明确的 Plane comment 能力，供 callback 直接调用：
+
+```ts
+createIssueComment({
+  planeIssueId,
+  commentHtml,
+}): Promise<void>
+```
+
+本次不做富样式卡片化，只保证：
+
+- comment 能被成功写入 Plane Issue
+- comment 结构稳定、可读
+
+### 6.3 Callback payload parsing
+
+`workflow-callback.ts` 中保留现有 dispatch 状态机逻辑，但调整 skill-specific parsing：
+
+- `arcflow-prd-to-tech`：回调 payload 中读取 `tech_doc_path`，并使用 docs repo 中间落盘路径对应的内容来源策略
+- `arcflow-tech-to-openapi`：读取 `openapi_path`
+- `arcflow-bug-analysis`：读取结构化字段并渲染为可评论文本
+
+为避免“Gateway 只拿到路径却拿不到内容”的问题，本次契约统一为：
+
+- success callback 必须同时包含 `content` 语义所需的完整输出文本以及产物路径
+
+具体形状：
+
+- `arcflow-prd-to-tech`：`{ tech_doc_path, content, plane_issue_id }`
+- `arcflow-tech-to-openapi`：`{ openapi_path, content, plane_issue_id }`
+- `arcflow-bug-analysis`：`{ summary, root_cause, suggested_fix, confidence, next_action, plane_issue_id }`
+
+这样 ArcFlow 不需要再回 NanoClaw 容器读取中间文件。
+
+### 6.4 CLI compatibility
+
+`nanoclaw/container/skills/arcflow-api/arcflow-api` 的 `workflow_callback` 子命令当前统一把成功载荷放到 `output` 字段。该行为保留，但调用方 skill 文档与测试必须更新为上述 payload。
+
+ArcFlow `callbackRoutes` 继续兼容：
+
+- `status=success` 时读取 `output`
+- `status=failed` 时读取 `error`
+
+不在本次改动回调 HTTP 包裹层字段，只收口 `output` 的内部结构。
+
+## 7. 数据流
+
+### 7.1 `arcflow-prd-to-tech`
+
+1. Plane / Web 触发 dispatch
+2. NanoClaw skill 读取 PRD 并生成技术设计 Markdown
+3. Skill success callback 发送：
+   - `tech_doc_path`
+   - `content`
+   - `plane_issue_id`
+4. Gateway callback：
+   - 写入 docs repo
+   - 更新 dispatch 成功
+   - 如有后续链路，保持现有派生机制
+
+### 7.2 `arcflow-tech-to-openapi`
+
+1. NanoClaw skill 读取技术设计文档并生成 OpenAPI yaml
+2. Success callback 发送：
+   - `openapi_path`
+   - `content`
+   - `plane_issue_id`
+3. Gateway callback：
+   - 写入 docs repo
+   - 如当前 execution context 存在，继续触发 `code_gen`
+
+### 7.3 `arcflow-bug-analysis`
+
+1. CI / iBuild failure 派生 `bug_analysis`
+2. NanoClaw skill 输出结构化分析结果
+3. Success callback 发送：
+   - `summary`
+   - `root_cause`
+   - `suggested_fix`
+   - `confidence`
+   - `next_action`
+   - `plane_issue_id`
+4. Gateway callback：
+   - 更新 `analysis_ready`
+   - 将结构化结果序列化到 workflow detail 可读摘要
+   - 评论回 Plane Issue
+
+## 8. 错误处理
+
+- callback 缺少必填字段：立即失败，dispatch 标记 `failed`
+- docs repo 写回失败：dispatch 标记 `failed`，execution 状态同步失败
+- Plane comment 失败：dispatch 标记 `failed`
+- skill 返回与契约不符：作为 side effect failure 处理，不静默降级
+
+本次不采用“部分成功”策略。P0 收口要求 side effect 明确成功，否则视为失败，避免主链路表面成功、实际产物未落地。
+
+## 9. 测试策略
+
+### 9.1 ArcFlow
+
+- `workflow-callback.test.ts`
+  - `prd_to_tech` success 会真实调用 docs writeback 依赖
+  - `tech_to_openapi` success 会真实调用 docs writeback 依赖
+  - `bug_analysis` success 会真实调用 Plane comment 依赖
+  - 缺字段时进入失败分支
+- 新增或补充 service tests
+  - docs writeback service
+  - Plane comment service
+
+### 9.2 NanoClaw
+
+- skill / CLI tests
+  - `workflow callback` 成功 payload 包含当前契约要求字段
+  - `bug_analysis` payload 改为结构化输出，不再沿用旧字段
+
+### 9.3 Cross-repo contract verification
+
+- 以文档为准，双侧测试共同覆盖
+- 后续任何 callback shape 变更必须同时改：
+  - ArcFlow parser tests
+  - NanoClaw sender tests
+  - 契约文档
+
+## 10. 风险与取舍
+
+- 风险：跨两个仓库的改动会增加一次性变更面
+  - 取舍：这是关闭 P0 的必要成本，不能只改单边
+- 风险：docs writeback 与 skill 生成路径语义不一致
+  - 取舍：统一要求 callback 同时携带内容与路径，避免 ArcFlow 回读容器内文件
+- 风险：Plane comment 的 HTML / Markdown 能力与预期不一致
+  - 取舍：先以最小可读评论落地，不做复杂富文本
+
+## 11. 实施范围总结
+
+本次实施将修改：
+
+- ArcFlow Gateway callback side effects
+- ArcFlow docs / Plane service 层
+- NanoClaw skill 文档与 callback payload
+- NanoClaw `arcflow-api` CLI 相关测试
+- 当前主线契约文档
+
+本次实施不会修改：
+
+- Web 页面交互
+- 自动修复执行器
+- Git webhook 空实现
+- 生产部署拓扑

--- a/docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md
+++ b/docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md
@@ -1,0 +1,149 @@
+# P1 Deployment Alignment Design
+
+> 日期：2026-04-20
+> 状态：Approved for immediate implementation
+> 范围：P1-4 的首个最小可落地子任务
+
+## 背景
+
+当前仓库已经明确：
+
+- ArcFlow 本仓核心服务运行目录应为 `/data/project/arcflow`
+- NanoClaw 生产运行目录应为 `/data/project/nanoclaw`
+- 历史验证报告已经记录服务器上存在 `/data/project/nanoclaw-fork` 与真实运行目录并存的漂移
+
+现状问题不是“服务不知道怎么启动”，而是：
+
+1. 当前仓库没有一个统一的、面向生产的操作入口来表达当前可信路径和标准动作。
+2. 更新、回滚、验证还主要散落在历史报告和 README 说明里，容易继续依赖人工记忆。
+3. 即使文档已经说明 NanoClaw 用 PM2、ArcFlow 用 Docker Compose，脚本层仍缺少统一的 `status / verify / rollback` 口径。
+
+## 目标
+
+本轮只关闭 P1-4 的最小子任务：
+
+1. 将根目录 `deploy.sh` 固化为当前生产运维入口。
+2. 明确 ArcFlow 与 NanoClaw 的单一可信路径与运行方式。
+3. 提供标准化的 `status / verify / rollback` 操作协议。
+4. 用自动化测试锁住脚本行为，避免后续继续漂移。
+
+## 非目标
+
+- 不改造 NanoClaw 独立仓部署方式。
+- 不实现跨服务器发布编排平台。
+- 不补 P1-2 的 tracing / alert / replay。
+- 不补 P1-1 的 Git webhook 真实业务逻辑。
+- 不做 P1-3 的多场景重复验证矩阵。
+
+## 方案对比
+
+### 方案 A：只补文档
+
+优点：
+
+- 改动最小
+
+缺点：
+
+- 无法约束后续脚本行为
+- 运维入口仍然分散
+
+### 方案 B：文档 + 统一脚本入口
+
+优点：
+
+- 文档和脚本同时成为当前口径
+- 可通过测试稳定协议
+- 后续扩展远程发布能力时有明确基座
+
+缺点：
+
+- 需要补一组脚本测试
+
+### 方案 C：直接上完整远程发布平台
+
+优点：
+
+- 一步到位
+
+缺点：
+
+- 超出 P1-4 最小闭环
+- 容易把本轮任务拖成大重构
+
+结论：采用方案 B。
+
+## 设计
+
+### 1. 统一脚本入口
+
+根目录 `deploy.sh` 继续保留为唯一入口，但协议改为显式子命令：
+
+- `deploy.sh sync [branch]`
+- `deploy.sh up [branch]`
+- `deploy.sh status`
+- `deploy.sh verify`
+- `deploy.sh rollback <git-ref>`
+
+约束：
+
+- `ArcFlow` 可信源码/运行目录固定为 `/data/project/arcflow`
+- `NanoClaw` 可信运行目录固定为 `/data/project/nanoclaw`
+- `NanoClaw` 的运行方式固定表达为 `pm2 describe arcflow-nanoclaw`
+- `rollback` 只回滚 ArcFlow 本仓，不隐式操作 NanoClaw 独立仓
+
+### 2. 标准化验证口径
+
+`verify` 子命令至少执行以下远程检查：
+
+- `docker compose ps`（ArcFlow 本仓）
+- `curl -sf http://127.0.0.1:3100/health`
+- `curl -I -sf http://127.0.0.1`
+- `pm2 describe arcflow-nanoclaw`
+- 输出当前可信目录说明
+
+这不是完整业务验收，只是生产部署后最小运维验证入口。
+
+### 3. 标准化回滚口径
+
+`rollback <git-ref>` 对 ArcFlow 本仓执行：
+
+1. `git fetch --all --tags`
+2. `git checkout <git-ref>`
+3. `docker compose up -d --build`
+4. 复用 `verify` 检查
+
+NanoClaw 回滚不在本轮自动化范围内，但 runbook 中必须明确写成独立仓操作。
+
+### 4. 文档收口
+
+新增一份部署 runbook，明确：
+
+- 单一可信路径
+- 日常更新步骤
+- 回滚步骤
+- 验证步骤
+- 历史漂移说明
+
+并在缺口清单中记录本轮 P1-4 的推进结果。
+
+## 测试策略
+
+先写脚本测试，再改脚本：
+
+- 使用 Bun test 调用 `deploy.sh`
+- 通过注入假的 `ssh` 可执行文件捕获远程命令
+- 验证 `status / verify / rollback` 会生成预期远程命令
+- 验证缺少 `git-ref` 的 `rollback` 会失败并提示用法
+
+## 验收标准
+
+满足以下条件即可视为完成本轮子任务：
+
+1. `deploy.sh` 暴露统一的 `sync / up / status / verify / rollback` 协议。
+2. 脚本中的远程路径与当前文档口径一致：
+   - ArcFlow: `/data/project/arcflow`
+   - NanoClaw: `/data/project/nanoclaw`
+3. 新增 runbook 明确更新、回滚、验证步骤。
+4. 自动化测试覆盖上述脚本协议。
+5. `docs/当前缺口清单_按优先级.md` 记录本轮推进结果。

--- a/docs/superpowers/specs/2026-04-20-p1-runtime-drift-check-design.md
+++ b/docs/superpowers/specs/2026-04-20-p1-runtime-drift-check-design.md
@@ -1,0 +1,69 @@
+# P1 Runtime Drift Check Design
+
+> 日期：2026-04-20
+> 状态：Approved for immediate implementation
+> 范围：P1-4 第二个最小子任务
+
+## 背景
+
+服务器实查结果已经确认：
+
+- `PM2` 当前运行 `arcflow-nanoclaw`，`script path=/data/project/nanoclaw/start.sh`
+- `/data/project/nanoclaw` 不是 git 仓库
+- `/data/project/nanoclaw-fork` 仍是 git 仓库，且存在未提交改动
+
+这说明当前“历史漂移”不是一个文档问题，而是服务器上的真实运行现状：
+
+1. 运行目录和 git 跟踪目录仍然分离
+2. `nanoclaw-fork` 上还有活跃修改，不能在没有确认的情况下直接删除或强制切换
+
+## 目标
+
+本轮不直接做危险的服务器收口，而是先补可执行的漂移检查能力：
+
+1. 在根目录 `deploy.sh` 中提供 `drift` 子命令
+2. 让运维入口能显式暴露 ArcFlow / NanoClaw 的运行目录与 git 目录是否一致
+3. 让后续做服务器实收口时有固定检查入口，而不是靠历史报告
+
+## 非目标
+
+- 不自动删除 `/data/project/nanoclaw-fork`
+- 不自动把 `/data/project/nanoclaw` 改造成 git worktree
+- 不自动切换 PM2 到新的脚本路径
+
+## 设计
+
+新增：
+
+- `./deploy.sh drift`
+
+检查内容：
+
+1. ArcFlow 目录 `/data/project/arcflow` 是否是 git 仓库
+2. NanoClaw 运行目录 `/data/project/nanoclaw` 是否是 git 仓库
+3. NanoClaw 漂移目录 `/data/project/nanoclaw-fork` 是否存在、是否是 git 仓库、是否有未提交改动
+4. PM2 当前 `arcflow-nanoclaw` 的 `script path` 与 `exec cwd`
+
+输出要求：
+
+- 不隐式修复
+- 返回可读的风险提示
+- 明确指出“运行目录非 git repo”与“fork 目录脏”这两类高风险状态
+
+## 测试策略
+
+TDD：
+
+1. 先给 `setup/deploy.test.ts` 增加 `drift` 命令的失败测试
+2. 校验脚本确实会执行：
+   - `pm2 describe arcflow-nanoclaw`
+   - `/data/project/nanoclaw` 的 git repo 检查
+   - `/data/project/nanoclaw-fork` 的存在性与 `git status --short`
+3. 再实现最小脚本逻辑直到测试通过
+
+## 验收标准
+
+1. `deploy.sh drift` 已可执行
+2. 自动化测试覆盖 `drift` 远程检查协议
+3. runbook 记录 `drift` 的用途与当前已知风险
+4. 缺口清单补充第二个子任务进展

--- a/docs/当前缺口清单_按优先级.md
+++ b/docs/当前缺口清单_按优先级.md
@@ -1,0 +1,299 @@
+# ArcFlow 当前缺口清单（按优先级）
+
+> 日期：2026-04-20
+> 适用范围：ArcFlow 当前主线开发与收口
+> 文档定位：记录当前仓库在 `2026-04-20` 时点的主要缺口，作为后续逐项关闭的执行清单。
+
+## 1. 结论
+
+ArcFlow 当前状态不是“还在搭框架”，而是：
+
+- 本仓主链路已经完成到 `Phase 3.6`
+- `PRD -> 技术设计 -> OpenAPI -> code_gen -> CI -> bug_analysis` 的仓内闭环已经跑通
+- 当前主要工作重心已经转向 `Phase 4`：稳定性、跨仓收口、生产验证、团队使用规范
+
+这份文档只记录**当前还缺什么**，不重复记录已完成能力。
+
+## 2. 当前判断依据
+
+本清单基于以下事实来源整理：
+
+- [README.md](../README.md)
+- [AI研发运营一体化平台_技术架构方案.md](AI研发运营一体化平台_技术架构方案.md)
+- `2026-04-16`、`2026-04-17` 的验证报告
+- 当前仓库代码现状（`packages/gateway`、`packages/web`）
+
+补充验证：
+
+- `bun run test` 已通过
+- `bun run --cwd packages/web build` 已通过
+
+## 3. 优先级定义
+
+- `P0`：不补就会持续阻塞主链路交付，或者文档承诺与实际实现存在明显缺口
+- `P1`：不立刻阻塞，但会明显影响生产稳定性、联调成本、运维成本
+- `P2`：重要但可延后，主要影响规模化使用、效率和体验
+
+## 4. P0 必须补
+
+### [x] P0-1 完成 NanoClaw 独立仓 `arcflow-api` skill 包发布、接线和验收
+
+#### P0-1 为什么是 P0
+
+- 当前文档已明确：本仓配套已完成，但 skill 包本体仍在独立仓持续跟进
+- `prd_to_tech`、`tech_to_openapi`、`bug_analysis` 的真实执行仍依赖独立仓状态
+
+#### P0-1 当前现状
+
+- ArcFlow 仓内的 Gateway 契约、Web artifact 渲染、dispatch / callback 配套已落地
+- NanoClaw 独立仓内 skill 包是否已稳定发布、是否与当前 Gateway 契约完全对齐，仍需继续确认
+
+#### P0-1 完成标准
+
+- 独立仓 skill 包发布完成，环境中使用的是明确版本
+- ArcFlow 与 NanoClaw 的请求/回调字段对齐，有可追溯的契约文档
+- 在真实环境完成至少一轮 `prd_to_tech`、`tech_to_openapi`、`bug_analysis` 联调验收
+
+#### P0-1 依赖
+
+- NanoClaw 独立仓
+- Gateway callback 契约
+
+完成日期：2026-04-20
+验证方式：`/Users/chenqi/code/nanoclaw` 中 `npm test -- src/arcflow-api-cli.test.ts` 通过，skill 文档与 CLI `workflow callback` 已对齐 strict contract，并支持 `@file` 大 payload 回调
+备注：`arcflow-prd-to-tech`、`arcflow-tech-to-openapi`、`arcflow-bug-analysis` 三个非交互 skill 的 callback 文档与测试已同步更新
+
+### [x] P0-2 将 callback 中的 docs / Plane 写回从占位实现改为正式实现
+
+#### P0-2 为什么是 P0
+
+- 当前主架构文档写的是：NanoClaw 结果通过 Gateway 回写 docs / Plane / 飞书
+- 但当前 Gateway 主入口里，`writeTechDesign`、`writeOpenApi`、`commentPlaneIssue` 还是占位日志实现
+
+#### P0-2 当前现状
+
+- `packages/gateway/src/index.ts` 中：
+  - `writeTechDesign(...)` 仅 `console.log`
+  - `writeOpenApi(...)` 仅 `console.log`
+  - `commentPlaneIssue(...)` 仅 `console.log`
+
+#### P0-2 完成标准
+
+- 技术设计文档 callback 能真实写入 docs repo
+- OpenAPI callback 能真实写入 docs repo
+- `bug_analysis` 或相关结果能真实评论回 Plane Issue
+- 失败路径有明确错误传播，不再只是日志输出
+
+#### P0-2 依赖
+
+- docs Git 写入能力
+- Plane API 写评论能力
+- callback payload 契约稳定
+
+完成日期：2026-04-20
+验证方式：`bun test packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts packages/gateway/src/services/workflow-callback.test.ts` 通过；`bun test packages/gateway/src/index.test.ts` 通过
+备注：Gateway 主入口已从 `console.log` 占位实现切换为真实 docs writeback 和 Plane comment side effect
+
+### [x] P0-3 固化 ArcFlow ↔ NanoClaw 跨仓契约，避免字段漂移
+
+#### P0-3 为什么是 P0
+
+- 现在主链路的一部分已经拆到独立仓执行
+- 如果没有明确契约版本、字段定义和兼容规则，很容易出现“本仓测试都过，但联调失败”
+
+#### P0-3 当前现状
+
+- callback 解析逻辑已经比较严格，字段错误会直接进入失败分支
+- 但契约治理还主要依赖代码和历史 spec，没有形成明确的变更约束
+
+#### P0-3 完成标准
+
+- request / callback payload 形成稳定文档
+- 必填字段、可选字段、错误语义、版本兼容规则明确
+- 修改契约时，ArcFlow 与 NanoClaw 两侧都有回归验证
+
+#### P0-3 依赖
+
+- P0-1
+- P0-2
+
+完成日期：2026-04-20
+验证方式：ArcFlow callback parser tests 与 NanoClaw CLI callback tests 同步通过；新增 [arcflow-nanoclaw-callback-contract.md](arcflow-nanoclaw-callback-contract.md) 作为当前有效契约
+备注：当前契约已明确 `prd_to_tech`、`tech_to_openapi`、`bug_analysis` 的 success/failed envelope 与 payload 形状
+
+## 5. P1 应尽快补
+
+### [ ] P1-1 补齐 Git webhook 的真实业务处理
+
+#### P1-1 当前现状
+
+- `/webhook/git` 当前只返回 `received`
+- 尚未真正触发 RAG sync、docs push 后续动作或 MR 相关处理
+
+#### P1-1 完成标准
+
+- 明确 Git webhook 需要承接哪些事件
+- 至少有一条真实业务链路接入并验证通过
+- 不再是空路由
+
+### [ ] P1-2 继续完成 Phase 4 稳定性与可观测性收口
+
+#### P1-2 当前现状
+
+- README 已明确 Phase 4 仍在进行中
+- dispatch / callback 可观测性已有补强，但还不是完整的生产级观测体系
+
+#### P1-2 建议范围
+
+- dispatch 超时诊断
+- callback replay / late callback 监控
+- 跨服务链路追踪
+- 错误告警和可定位性
+- 重试与幂等策略统一
+
+#### P1-2 完成标准
+
+- 关键链路有稳定观测面板或标准排障入口
+- 主要失败模式有明确告警和诊断信息
+- 生产问题不需要依赖人工翻日志才能定位
+
+### [ ] P1-3 补更多真实生产场景重复验证
+
+#### P1-3 当前现状
+
+- 当前验证已证明“本仓闭环”成立
+- 但离“高频、重复、稳定地跑”仍有距离
+
+#### P1-3 完成标准
+
+- 针对主链路形成重复验证清单
+- 至少覆盖：成功、失败、超时、回调异常、重复回调、多 target repo
+- 每次部署后可以重复执行
+
+### [ ] P1-4 统一生产部署口径，消除环境漂移
+
+#### P1-4 当前现状
+
+- 现有验证报告已记录 server 上存在运行目录与 git 跟踪目录漂移
+- 这会导致代码源头、运行实例、排障对象不一致
+
+#### P1-4 本轮已完成子任务（2026-04-20）
+
+- 已将根目录 `deploy.sh` 收敛为统一入口，补齐 `sync / up / status / verify / rollback` 标准命令
+- 已继续补齐 `./deploy.sh drift`，用于显式检查 ArcFlow / NanoClaw 运行目录与 git 跟踪目录漂移
+- 已新增 `setup/production-runbook.md`，明确当前可信路径：
+  - ArcFlow：`/data/project/arcflow`
+  - NanoClaw：`/data/project/nanoclaw`
+- 已将服务器历史漂移目录归档为 `/data/project/nanoclaw-fork.backup-20260420-173251`
+- 已将 `/data/project/nanoclaw` 补齐为 git 仓库，不再同时依赖独立 git 跟踪目录做默认排障
+
+#### P1-4 当前剩余缺口
+
+- NanoClaw 运行目录虽然已成为 git 仓库，但仍是 dirty worktree，说明独立仓改动还没有完成正式提交/发布
+- NanoClaw 独立仓仍需要后续补自己的标准化回滚 / 验证入口，避免再次形成双口径
+
+#### P1-4 完成标准
+
+- 生产运行目录、源码目录、发布流程统一
+- 文档中明确单一可信部署路径
+- 更新、回滚、验证步骤标准化
+
+进展日期：2026-04-20
+验证方式：`bun test setup/deploy.test.ts` 通过；`bunx markdownlint-cli2 "setup/production-runbook.md" "docs/当前缺口清单_按优先级.md" "docs/superpowers/specs/2026-04-20-p1-deployment-alignment-design.md" "docs/superpowers/plans/2026-04-20-p1-deployment-alignment.md" "docs/superpowers/specs/2026-04-20-p1-runtime-drift-check-design.md" "docs/superpowers/plans/2026-04-20-p1-runtime-drift-check.md"` 通过；`cd /Users/chenqi/code/nanoclaw && npm run build` 与服务器 `cd /data/project/nanoclaw && npm run build` 均通过
+
+## 6. P2 重要但不阻塞
+
+### [ ] P2-1 稳定化自动修复链路
+
+#### P2-1 当前现状
+
+- `bug_analysis` 已闭环
+- 但“分析完成后自动修复”还不是稳定能力
+
+#### P2-1 完成标准
+
+- 明确自动修复触发条件
+- 明确人工接管边界
+- 对修复结果有可验证闭环
+
+### [ ] P2-2 沉淀团队操作规范和 SOP
+
+#### P2-2 当前现状
+
+- 系统涉及 Web、Gateway、NanoClaw、Plane、Feishu、Git、CI
+- 多人协作若没有统一操作手册，会长期依赖个人经验
+
+#### P2-2 完成标准
+
+- 形成面向开发、联调、运维的最小操作手册
+- 常见流程有明确入口和责任边界
+
+### [ ] P2-3 建立更完整的业务验收清单
+
+#### P2-3 当前现状
+
+- 目前测试覆盖偏技术链路
+- 还需要补更多真实业务场景验收
+
+#### P2-3 建议覆盖
+
+- 多 workspace
+- 多 repo
+- 多 target
+- callback 异常
+- 人工接管
+- bug_analysis 后续处理
+
+### [ ] P2-4 持续打磨 Web 展示与操作体验
+
+#### P2-4 当前现状
+
+- Workflow Detail、artifact 渲染、bug report summary 已有基础
+- 但要支撑长期团队使用，筛选、可读性、操作入口仍需要持续优化
+
+#### P2-4 完成标准
+
+- 关键页面能支撑日常排查和推进
+- 用户不需要依赖数据库或日志就能判断当前工作流状态
+
+## 7. 建议开发顺序
+
+建议按下面顺序逐项关闭：
+
+1. `P0-2` callback 正式写回 docs / Plane
+2. `P0-1` NanoClaw skill 包发布与联调验收
+3. `P0-3` 固化跨仓契约
+4. `P1-4` 统一部署口径
+5. `P1-2` 稳定性与可观测性继续收口
+6. `P1-1` Git webhook 真实落地
+7. `P1-3` 重复验证体系
+8. `P2-*` 逐步补齐
+
+## 8. 关闭规则
+
+后续每完成一项，建议按以下方式更新本文件：
+
+- 将对应条目标记为 `[x]`
+- 在条目下补一行 `完成日期`
+- 补一行 `验证方式`
+- 如涉及实现偏差，补一行 `备注`
+
+推荐格式：
+
+```md
+### [x] P0-2 将 callback 中的 docs / Plane 写回从占位实现改为正式实现
+
+完成日期：2026-04-XX
+验证方式：bun test ... / 联调 ...
+备注：技术设计和 OpenAPI 已写回 docs，Plane 评论已接通
+```
+
+## 9. 备注
+
+这份文档的目标不是长期保存所有历史判断，而是作为**当前阶段的执行清单**。
+
+如果后续主线发生变化，应优先同步：
+
+- [README.md](../README.md)
+- [AI研发运营一体化平台_技术架构方案.md](AI研发运营一体化平台_技术架构方案.md)
+- 本文档

--- a/packages/gateway/src/index.ts
+++ b/packages/gateway/src/index.ts
@@ -21,6 +21,8 @@ import { createRagIndex } from "./services/rag-index";
 import { createRagSearch } from "./services/rag-search";
 import { createGitAdapter } from "./services/rag-git-adapter";
 import { createCallbackHandler } from "./services/workflow-callback";
+import { createWorkflowWritebackService } from "./services/workflow-writeback";
+import { commentPlaneIssue as postPlaneIssueComment } from "./services/plane";
 import { createScheduler } from "./services/scheduler";
 import { triggerWorkflow } from "./services/workflow";
 import type { WorkflowDispatchStatus } from "./types";
@@ -97,6 +99,7 @@ app.route("/api/arcflow", arcflowToolRoutes);
 
 // ── RAG + callback routes ──────────────────────────────────────────────────────
 const systemSecret = process.env.SYSTEM_SECRET ?? process.env.NANOCLAW_DISPATCH_SECRET ?? "";
+const workflowWriteback = createWorkflowWritebackService();
 
 if (ragDb) {
   const embedder = createEmbeddingClient({
@@ -130,18 +133,22 @@ if (ragDb) {
 
 // Callback route (always mounted; handler stubs out deps when ragDb absent)
 const callbackHandler = createCallbackHandler({
-  writeTechDesign: async ({ workspaceId, planeIssueId, content }) => {
-    console.log(
-      `[callback] writeTechDesign ws=${workspaceId} issue=${planeIssueId ?? "-"} len=${content.length}`,
-    );
+  writeTechDesign: async ({ workspaceId, relativePath, content }) => {
+    await workflowWriteback.writeDoc({
+      workspaceId,
+      relativePath,
+      content,
+    });
   },
-  writeOpenApi: async ({ workspaceId, planeIssueId, content }) => {
-    console.log(
-      `[callback] writeOpenApi ws=${workspaceId} issue=${planeIssueId ?? "-"} len=${content.length}`,
-    );
+  writeOpenApi: async ({ workspaceId, relativePath, content }) => {
+    await workflowWriteback.writeDoc({
+      workspaceId,
+      relativePath,
+      content,
+    });
   },
-  commentPlaneIssue: async ({ planeIssueId, content }) => {
-    console.log(`[callback] commentPlaneIssue issue=${planeIssueId} len=${content.length}`);
+  commentPlaneIssue: async ({ workspaceId, planeIssueId, content }) => {
+    await postPlaneIssueComment(workspaceId, planeIssueId, content);
   },
   loadDispatch: async (id) => {
     const db = getDb();

--- a/packages/gateway/src/services/plane.test.ts
+++ b/packages/gateway/src/services/plane.test.ts
@@ -9,7 +9,24 @@ mock.module("../config", () => ({
     }),
 }));
 
-const { getIssue, updateIssueState, createBugIssue, listIssuesByAssignee } =
+const getWorkspace = mock(() => ({
+  id: 1,
+  name: "Test WS",
+  slug: "test-ws",
+  plane_project_id: "proj-1",
+  plane_workspace_slug: "plane-ws",
+  wiki_path_prefix: null,
+  git_repos: "{}",
+  feishu_chat_id: null,
+  created_at: "",
+  updated_at: "",
+}));
+
+mock.module("../db/queries", () => ({
+  getWorkspace,
+}));
+
+const { getIssue, updateIssueState, createBugIssue, listIssuesByAssignee, commentPlaneIssue } =
   await import("./plane");
 
 describe("plane service", () => {
@@ -184,6 +201,32 @@ describe("plane service", () => {
         "http://localhost:8082/api/v1/workspaces/test-workspace/projects/proj-1/issues/?assignee__email=me%40example.com",
       );
       expect(items).toEqual([{ id: "ISS-1", name: "Need review" }]);
+    });
+  });
+
+  describe("commentPlaneIssue", () => {
+    it("posts comment_html to the Plane work-item comment endpoint", async () => {
+      mockFetchFn = mock(async (url: string, init: RequestInit) => {
+        fetchCalls.push({ url, init });
+        return new Response(JSON.stringify({ id: "c-1" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+      globalThis.fetch = mockFetchFn as unknown as typeof fetch;
+
+      await commentPlaneIssue(1, "ISS-22", "First line\nSecond line");
+
+      expect(fetchCalls.length).toBe(1);
+      expect(fetchCalls[0].url).toBe(
+        "http://localhost:8082/api/v1/workspaces/plane-ws/projects/proj-1/work-items/ISS-22/comments/",
+      );
+      expect(fetchCalls[0].init.method).toBe("POST");
+      const body = JSON.parse(fetchCalls[0].init.body as string);
+      expect(body).toEqual({ comment_html: "First line<br />Second line" });
+      const headers = fetchCalls[0].init.headers as Record<string, string>;
+      expect(headers["X-API-Key"]).toBe("test-token");
+      expect(getWorkspace).toHaveBeenCalledWith(1);
     });
   });
 });

--- a/packages/gateway/src/services/plane.ts
+++ b/packages/gateway/src/services/plane.ts
@@ -1,3 +1,4 @@
+import { getWorkspace } from "../db/queries";
 import { getConfig } from "../config";
 
 interface PlaneIssue {
@@ -7,6 +8,10 @@ interface PlaneIssue {
   state: string;
   priority: string;
   labels: string[];
+}
+
+function toCommentHtml(content: string): string {
+  return content.trim().replace(/\n/g, "<br />");
 }
 
 async function planeRequest(
@@ -187,4 +192,35 @@ export async function listIssuesByAssignee(
     0,
   )) as { results?: PlaneIssueListItem[] };
   return result.results ?? [];
+}
+
+export async function commentPlaneIssue(
+  workspaceId: number | string,
+  workItemId: string,
+  content: string,
+): Promise<void> {
+  const resolvedWorkspaceId = Number(workspaceId);
+  if (!Number.isFinite(resolvedWorkspaceId) || resolvedWorkspaceId <= 0) {
+    throw new Error("workspaceId is required");
+  }
+
+  const workspace = getWorkspace(resolvedWorkspaceId);
+  if (!workspace) {
+    throw new Error(`workspace ${resolvedWorkspaceId} not found`);
+  }
+  if (!workspace.plane_workspace_slug) {
+    throw new Error(`workspace ${resolvedWorkspaceId} has no Plane workspace slug`);
+  }
+  if (!workspace.plane_project_id) {
+    throw new Error(`workspace ${resolvedWorkspaceId} has no Plane project id`);
+  }
+
+  await planeRequest(
+    workspace.plane_workspace_slug,
+    `/projects/${workspace.plane_project_id}/work-items/${workItemId}/comments/`,
+    {
+      method: "POST",
+      body: JSON.stringify({ comment_html: toCommentHtml(content) }),
+    },
+  );
 }

--- a/packages/gateway/src/services/workflow-callback.test.ts
+++ b/packages/gateway/src/services/workflow-callback.test.ts
@@ -56,13 +56,157 @@ describe("workflow-callback dispatcher", () => {
       dispatch_id: "d1",
       skill: "arcflow-prd-to-tech",
       status: "success",
-      result: { content: "# T\nbody" },
+      result: { tech_doc_path: "docs/tech/design.md", content: "# T\nbody" },
     });
     expect(ok).toBe(true);
-    expect((calls[0] as [string, unknown])[0]).toBe("tech");
-    expect(((calls[0] as [string, { content: string }])[1] as { content: string }).content).toBe(
-      "# T\nbody",
-    );
+    expect(calls[0]).toEqual([
+      "tech",
+      {
+        workspaceId: "w",
+        planeIssueId: "PROJ-1",
+        relativePath: "docs/tech/design.md",
+        content: "# T\nbody",
+      },
+    ]);
+  });
+
+  it("normalizes prd-to-tech callback paths with posix separators", async () => {
+    const calls: unknown[] = [];
+    const handler = createCallbackHandler({
+      writeTechDesign: async (x) => {
+        calls.push(x);
+      },
+      writeOpenApi: async () => {},
+      commentPlaneIssue: async () => {},
+      markSubtaskProgress: async () => {},
+      loadDispatch: async () => ({
+        id: "d1",
+        workspaceId: "w",
+        skill: "arcflow-prd-to-tech",
+        planeIssueId: "PROJ-1",
+        status: "pending",
+      }),
+      markDone: async () => true,
+    });
+
+    const ok = await handler.handle({
+      dispatch_id: "d1",
+      skill: "arcflow-prd-to-tech",
+      status: "success",
+      result: { tech_doc_path: "docs\\tech\\design.md", content: "# T\nbody" },
+    });
+
+    expect(ok).toBe(true);
+    expect(calls[0]).toEqual({
+      workspaceId: "w",
+      planeIssueId: "PROJ-1",
+      relativePath: "docs/tech/design.md",
+      content: "# T\nbody",
+    });
+  });
+
+  it("rejects incomplete prd-to-tech callback payloads", async () => {
+    const handler = createCallbackHandler({
+      writeTechDesign: async () => {},
+      writeOpenApi: async () => {},
+      commentPlaneIssue: async () => {},
+      markSubtaskProgress: async () => {},
+      loadDispatch: async () => ({
+        id: "d1",
+        workspaceId: "w",
+        skill: "arcflow-prd-to-tech",
+        planeIssueId: "PROJ-1",
+        status: "pending",
+      }),
+      markDone: async () => true,
+    });
+
+    await expect(
+      handler.handle({
+        dispatch_id: "d1",
+        skill: "arcflow-prd-to-tech",
+        status: "success",
+        result: { content: "# T\nbody" },
+      }),
+    ).rejects.toThrow("tech design callback payload is incomplete");
+  });
+
+  it("rejects incomplete tech-to-openapi callback payloads", async () => {
+    const handler = createCallbackHandler({
+      writeTechDesign: async () => {},
+      writeOpenApi: async () => {},
+      commentPlaneIssue: async () => {},
+      markSubtaskProgress: async () => {},
+      loadDispatch: async () => ({
+        id: "d1",
+        workspaceId: "w",
+        skill: "arcflow-tech-to-openapi",
+        planeIssueId: "PROJ-2",
+        status: "pending",
+      }),
+      markDone: async () => true,
+    });
+
+    await expect(
+      handler.handle({
+        dispatch_id: "d1",
+        skill: "arcflow-tech-to-openapi",
+        status: "success",
+        result: { openapi_path: "specs/api/openapi.yaml" },
+      }),
+    ).rejects.toThrow("openapi callback payload is incomplete");
+  });
+
+  it("rejects unsafe prd-to-tech callback paths", async () => {
+    const handler = createCallbackHandler({
+      writeTechDesign: async () => {},
+      writeOpenApi: async () => {},
+      commentPlaneIssue: async () => {},
+      markSubtaskProgress: async () => {},
+      loadDispatch: async () => ({
+        id: "d1",
+        workspaceId: "w",
+        skill: "arcflow-prd-to-tech",
+        planeIssueId: "PROJ-1",
+        status: "pending",
+      }),
+      markDone: async () => true,
+    });
+
+    await expect(
+      handler.handle({
+        dispatch_id: "d1",
+        skill: "arcflow-prd-to-tech",
+        status: "success",
+        result: { tech_doc_path: "../escape.md", content: "# T\nbody" },
+      }),
+    ).rejects.toThrow("tech design callback path is invalid");
+  });
+
+  it("rejects unsafe tech-to-openapi callback paths", async () => {
+    const handler = createCallbackHandler({
+      writeTechDesign: async () => {},
+      writeOpenApi: async () => {},
+      commentPlaneIssue: async () => {},
+      markSubtaskProgress: async () => {},
+      loadDispatch: async () => ({
+        id: "d1",
+        workspaceId: "w",
+        skill: "arcflow-tech-to-openapi",
+        planeIssueId: "PROJ-2",
+        status: "pending",
+      }),
+      markDone: async () => true,
+    });
+
+    await expect(
+      handler.handle({
+        dispatch_id: "d1",
+        skill: "arcflow-tech-to-openapi",
+        status: "success",
+        result: { openapi_path: "/tmp/openapi.yaml", content: "openapi: 3.1.0" },
+      }),
+    ).rejects.toThrow("openapi callback path is invalid");
   });
 
   it("idempotent: second callback returns false", async () => {
@@ -91,13 +235,11 @@ describe("workflow-callback dispatcher", () => {
       skill: "arcflow-bug-analysis",
       status: "success",
       result: {
-        content: JSON.stringify({
-          summary: "callback summary",
-          root_cause: "callback root cause",
-          suggested_fix: "callback suggested fix",
-          confidence: "high",
-          next_action: "auto_fix_candidate",
-        }),
+        summary: "callback summary",
+        root_cause: "callback root cause",
+        suggested_fix: "callback suggested fix",
+        confidence: "high",
+        next_action: "auto_fix_candidate",
         planeIssueId: "PROJ-9",
       },
     });
@@ -106,13 +248,11 @@ describe("workflow-callback dispatcher", () => {
       skill: "arcflow-bug-analysis",
       status: "success",
       result: {
-        content: JSON.stringify({
-          summary: "callback summary",
-          root_cause: "callback root cause",
-          suggested_fix: "callback suggested fix",
-          confidence: "high",
-          next_action: "auto_fix_candidate",
-        }),
+        summary: "callback summary",
+        root_cause: "callback root cause",
+        suggested_fix: "callback suggested fix",
+        confidence: "high",
+        next_action: "auto_fix_candidate",
         planeIssueId: "PROJ-9",
       },
     });
@@ -174,13 +314,11 @@ describe("workflow-callback dispatcher", () => {
       skill: "arcflow-bug-analysis",
       status: "success",
       result: {
-        content: JSON.stringify({
-          summary: "Type mismatch in payload parser",
-          root_cause: "branch_name optionality was ignored",
-          suggested_fix: "Guard fallback lookup",
-          confidence: "medium",
-          next_action: "manual_handoff",
-        }),
+        summary: "<script>alert(1)</script>",
+        root_cause: "branch_name & optionality was ignored",
+        suggested_fix: "Guard <fallback> lookup",
+        confidence: "medium",
+        next_action: "manual_handoff",
       },
     });
 
@@ -194,7 +332,17 @@ describe("workflow-callback dispatcher", () => {
         output_ref: expect.stringContaining('"next_action":"manual_handoff"'),
       }),
     );
-    expect(commentPlaneIssue).toHaveBeenCalled();
+    expect(commentPlaneIssue).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: "3",
+        planeIssueId: "ISS-401",
+        content: expect.stringContaining("<h2>Bug Analysis Summary</h2>"),
+      }),
+    );
+    expect(commentPlaneIssue.mock.calls[0]?.[0].content).toContain(
+      "&lt;script&gt;alert(1)&lt;/script&gt;",
+    );
+    expect(commentPlaneIssue.mock.calls[0]?.[0].content).toContain("&amp;");
     expect(updateExecutionStatus).toHaveBeenCalledWith(41, "success");
   });
 
@@ -217,9 +365,11 @@ describe("workflow-callback dispatcher", () => {
         dispatch_id: "d-bug",
         skill: "arcflow-bug-analysis",
         status: "success",
-        result: { content: '{"summary":"missing fields"}' },
+        result: {
+          content: '{"summary":"missing fields"}',
+        },
       }),
-    ).rejects.toThrow();
+    ).rejects.toThrow("bug analysis result is incomplete");
 
     expect(markSubtaskProgress).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -313,12 +463,8 @@ describe("workflow-callback dispatcher", () => {
       skill: "arcflow-tech-to-openapi",
       status: "success",
       result: {
-        content: JSON.stringify({
-          execution_id: 7,
-          target: "backend",
-          branch_name: "feature/ISS-120-backend",
-          repo_name: "backend",
-        }),
+        openapi_path: "specs/api/openapi.yaml",
+        content: "openapi: 3.1.0",
       },
     });
 
@@ -470,7 +616,7 @@ describe("workflow-callback dispatcher", () => {
       dispatch_id: "d-openapi",
       skill: "arcflow-tech-to-openapi",
       status: "success",
-      result: { content: "openapi: 3.1.0" },
+      result: { openapi_path: "specs/api/openapi.yaml", content: "openapi: 3.1.0" },
     });
 
     expect(handled).toBe(true);
@@ -800,7 +946,7 @@ describe("workflow-callback dispatcher", () => {
         dispatch_id: "d-openapi",
         skill: "arcflow-tech-to-openapi",
         status: "success",
-        result: { content: "openapi: 3.1.0" },
+        result: { openapi_path: "specs/api/openapi.yaml", content: "openapi: 3.1.0" },
       }),
     ).rejects.toThrow("openapi write failed");
 

--- a/packages/gateway/src/services/workflow-callback.ts
+++ b/packages/gateway/src/services/workflow-callback.ts
@@ -1,3 +1,4 @@
+import { posix as pathPosix } from "node:path";
 import { updateWorkflowSubtaskStatusByStage } from "../db/queries";
 import type { WorkflowDispatchStatus, WorkflowStatus } from "../types";
 
@@ -22,14 +23,20 @@ export interface CallbackDeps {
   writeTechDesign: (x: {
     workspaceId: string;
     planeIssueId?: string;
+    relativePath: string;
     content: string;
   }) => Promise<void>;
   writeOpenApi: (x: {
     workspaceId: string;
     planeIssueId?: string;
+    relativePath: string;
     content: string;
   }) => Promise<void>;
-  commentPlaneIssue: (x: { planeIssueId: string; content: string }) => Promise<void>;
+  commentPlaneIssue: (x: {
+    workspaceId: string;
+    planeIssueId: string;
+    content: string;
+  }) => Promise<void>;
   loadDispatch: (id: string) => Promise<DispatchRecord | null>;
   claimDispatch?: (id: string) => Promise<boolean>;
   releaseClaim?: (id: string) => Promise<boolean>;
@@ -68,7 +75,18 @@ export interface CallbackPayload {
   dispatch_id: string;
   skill?: string;
   status: "success" | "failed";
-  result?: { content: string; planeIssueId?: string };
+  result?: {
+    content?: string;
+    planeIssueId?: string;
+    tech_doc_path?: string;
+    openapi_path?: string;
+    summary?: unknown;
+    root_cause?: unknown;
+    suggested_fix?: unknown;
+    confidence?: unknown;
+    next_action?: unknown;
+    [key: string]: unknown;
+  };
   error?: string;
 }
 
@@ -107,6 +125,23 @@ function parseExecutionContext(input: unknown) {
         : undefined,
     input_path: typeof payload.input_path === "string" ? payload.input_path : undefined,
   };
+}
+
+function normalizeCallbackPath(rawPath: string, invalidMessage: string) {
+  const trimmed = rawPath.trim();
+  const posixPath = trimmed.replace(/\\/g, "/");
+
+  if (!trimmed) throw new Error(invalidMessage);
+  if (/^[A-Za-z]:[\\/]/.test(trimmed) || pathPosix.isAbsolute(posixPath)) {
+    throw new Error(invalidMessage);
+  }
+
+  const normalized = pathPosix.normalize(posixPath);
+  if (!normalized || normalized === "." || normalized === ".." || normalized.startsWith("../")) {
+    throw new Error(invalidMessage);
+  }
+
+  return normalized;
 }
 
 function parseCodegenResult(content: string) {
@@ -163,26 +198,66 @@ function parseBugAnalysisDispatchInput(input: unknown) {
   };
 }
 
-function parseBugAnalysisResult(content: string) {
-  const parsed = JSON.parse(content) as {
-    summary?: unknown;
-    root_cause?: unknown;
-    suggested_fix?: unknown;
-    confidence?: unknown;
-    next_action?: unknown;
-  };
+function parseTechDesignResult(result: CallbackPayload["result"]) {
+  if (!result || typeof result !== "object") {
+    throw new Error("tech design callback payload is incomplete");
+  }
 
-  const summary = typeof parsed.summary === "string" ? parsed.summary.trim() : "";
-  const rootCause = typeof parsed.root_cause === "string" ? parsed.root_cause.trim() : "";
-  const suggestedFix = typeof parsed.suggested_fix === "string" ? parsed.suggested_fix.trim() : "";
+  const content = typeof result.content === "string" ? result.content : "";
+  const techDocPath =
+    typeof result.tech_doc_path === "string"
+      ? normalizeCallbackPath(result.tech_doc_path, "tech design callback path is invalid")
+      : "";
+
+  if (!content || !techDocPath) {
+    throw new Error("tech design callback payload is incomplete");
+  }
+
+  return {
+    relativePath: techDocPath,
+    content,
+  };
+}
+
+function parseOpenApiResult(result: CallbackPayload["result"]) {
+  if (!result || typeof result !== "object") {
+    throw new Error("openapi callback payload is incomplete");
+  }
+
+  const content = typeof result.content === "string" ? result.content : "";
+  const openapiPath =
+    typeof result.openapi_path === "string"
+      ? normalizeCallbackPath(result.openapi_path, "openapi callback path is invalid")
+      : "";
+
+  if (!content || !openapiPath) {
+    throw new Error("openapi callback payload is incomplete");
+  }
+
+  return {
+    relativePath: openapiPath,
+    content,
+  };
+}
+
+function parseBugAnalysisResult(result: CallbackPayload["result"]) {
+  if (!result || typeof result !== "object") {
+    throw new Error("bug analysis result is incomplete");
+  }
+
+  const summary = typeof result.summary === "string" ? result.summary.trim() : "";
+  const rootCause = typeof result.root_cause === "string" ? result.root_cause.trim() : "";
+  const suggestedFix = typeof result.suggested_fix === "string" ? result.suggested_fix.trim() : "";
+  const confidence = typeof result.confidence === "string" ? result.confidence : "";
+  const nextAction = typeof result.next_action === "string" ? result.next_action : "";
 
   if (!summary || !rootCause || !suggestedFix) {
     throw new Error("bug analysis result is incomplete");
   }
-  if (!["high", "medium", "low"].includes(String(parsed.confidence))) {
+  if (!["high", "medium", "low"].includes(confidence)) {
     throw new Error("bug analysis confidence is invalid");
   }
-  if (!["auto_fix_candidate", "manual_handoff"].includes(String(parsed.next_action))) {
+  if (!["auto_fix_candidate", "manual_handoff"].includes(nextAction)) {
     throw new Error("bug analysis next_action is invalid");
   }
 
@@ -190,9 +265,39 @@ function parseBugAnalysisResult(content: string) {
     summary,
     root_cause: rootCause,
     suggested_fix: suggestedFix,
-    confidence: parsed.confidence as "high" | "medium" | "low",
-    next_action: parsed.next_action as "auto_fix_candidate" | "manual_handoff",
+    confidence: confidence as "high" | "medium" | "low",
+    next_action: nextAction as "auto_fix_candidate" | "manual_handoff",
   };
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function formatBugAnalysisComment(report: {
+  summary: string;
+  root_cause: string;
+  suggested_fix: string;
+  confidence: "high" | "medium" | "low";
+  next_action: "auto_fix_candidate" | "manual_handoff";
+}) {
+  return [
+    "<div>",
+    "<h2>Bug Analysis Summary</h2>",
+    "<ul>",
+    `<li><strong>Summary:</strong> ${escapeHtml(report.summary)}</li>`,
+    `<li><strong>Root cause:</strong> ${escapeHtml(report.root_cause)}</li>`,
+    `<li><strong>Suggested fix:</strong> ${escapeHtml(report.suggested_fix)}</li>`,
+    `<li><strong>Confidence:</strong> ${escapeHtml(report.confidence)}</li>`,
+    `<li><strong>Next action:</strong> ${escapeHtml(report.next_action)}</li>`,
+    "</ul>",
+    "</div>",
+  ].join("");
 }
 
 export function createCallbackHandler(deps: CallbackDeps) {
@@ -228,7 +333,8 @@ export function createCallbackHandler(deps: CallbackDeps) {
       const claimed = (await deps.claimDispatch?.(p.dispatch_id)) ?? true;
       if (!claimed) return false;
 
-      const content = p.result?.content ?? "";
+      const result = p.result;
+      const content = typeof result?.content === "string" ? result.content : "";
       const piid = p.result?.planeIssueId ?? rec.planeIssueId;
       const markSubtaskProgress = async (input: {
         execution_id: number;
@@ -327,9 +433,21 @@ export function createCallbackHandler(deps: CallbackDeps) {
             await deps.updateExecutionStatus?.(dispatchInput.execution_id, "failed", p.error);
           }
         } else if (skill === "arcflow-prd-to-tech") {
-          await deps.writeTechDesign({ workspaceId: rec.workspaceId, planeIssueId: piid, content });
+          const techDesign = parseTechDesignResult(result);
+          await deps.writeTechDesign({
+            workspaceId: rec.workspaceId,
+            planeIssueId: piid,
+            relativePath: techDesign.relativePath,
+            content: techDesign.content,
+          });
         } else if (skill === "arcflow-tech-to-openapi") {
-          await deps.writeOpenApi({ workspaceId: rec.workspaceId, planeIssueId: piid, content });
+          const openApi = parseOpenApiResult(result);
+          await deps.writeOpenApi({
+            workspaceId: rec.workspaceId,
+            planeIssueId: piid,
+            relativePath: openApi.relativePath,
+            content: openApi.content,
+          });
           const context = parseExecutionContext(rec.input);
           if (deps.triggerWorkflow && context.execution_id) {
             await deps.triggerWorkflow({
@@ -345,7 +463,7 @@ export function createCallbackHandler(deps: CallbackDeps) {
           }
         } else if (skill === "arcflow-bug-analysis") {
           const dispatchInput = parseBugAnalysisDispatchInput(rec.input);
-          const report = parseBugAnalysisResult(content);
+          const report = parseBugAnalysisResult(result);
           await markSubtaskProgress({
             execution_id: dispatchInput.execution_id,
             target: dispatchInput.target,
@@ -357,7 +475,13 @@ export function createCallbackHandler(deps: CallbackDeps) {
             log_url: dispatchInput.log_url,
             output_ref: JSON.stringify(report),
           });
-          if (piid) await deps.commentPlaneIssue({ planeIssueId: piid, content });
+          if (piid) {
+            await deps.commentPlaneIssue({
+              workspaceId: rec.workspaceId,
+              planeIssueId: piid,
+              content: formatBugAnalysisComment(report),
+            });
+          }
           await deps.updateExecutionStatus?.(dispatchInput.execution_id, "success");
         } else if (skill === "arcflow-code-gen") {
           const result = parseCodegenResult(content);

--- a/packages/gateway/src/services/workflow-writeback.test.ts
+++ b/packages/gateway/src/services/workflow-writeback.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from "bun:test";
+
+const getWorkspace = mock(() => ({
+  id: 12,
+  name: "Workspace",
+  slug: "workspace",
+  plane_project_id: "proj-7",
+  plane_workspace_slug: "plane-ws",
+  wiki_path_prefix: null,
+  git_repos: JSON.stringify({ docs: "git@ex:docs.git" }),
+  feishu_chat_id: null,
+  created_at: "",
+  updated_at: "",
+}));
+
+mock.module("../db/queries", () => ({
+  getWorkspace,
+}));
+
+const registerRepoUrl = mock(() => {});
+const ensureRepo = mock(async () => undefined);
+const writeAndPush = mock(async () => undefined);
+
+mock.module("./git", () => ({
+  registerRepoUrl,
+  ensureRepo,
+  writeAndPush,
+}));
+
+const { createWorkflowWritebackService } = await import("./workflow-writeback");
+
+describe("workflow writeback service", () => {
+  beforeEach(() => {
+    getWorkspace.mockClear();
+    registerRepoUrl.mockClear();
+    ensureRepo.mockClear();
+    writeAndPush.mockClear();
+  });
+
+  afterEach(() => {
+    getWorkspace.mockClear();
+    registerRepoUrl.mockClear();
+    ensureRepo.mockClear();
+    writeAndPush.mockClear();
+  });
+
+  it("writes generated docs into the workspace docs repo", async () => {
+    const service = createWorkflowWritebackService();
+
+    await service.writeDoc({
+      workspaceId: 12,
+      relativePath: "tech/design.md",
+      content: "# Design\nbody",
+    });
+
+    expect(getWorkspace).toHaveBeenCalledWith(12);
+    expect(registerRepoUrl).toHaveBeenCalledWith("ws-12-docs", "git@ex:docs.git");
+    expect(ensureRepo).toHaveBeenCalledWith("ws-12-docs");
+    expect(writeAndPush).toHaveBeenCalledWith(
+      "ws-12-docs",
+      "tech/design.md",
+      "# Design\nbody",
+      "docs: write tech/design.md",
+    );
+  });
+
+  it("fails fast when relativePath is missing", async () => {
+    const service = createWorkflowWritebackService();
+
+    await expect(
+      // @ts-expect-error - deliberate legacy payload shape
+      service.writeDoc({ workspaceId: 12, content: "body" }),
+    ).rejects.toThrow("relativePath is required");
+
+    expect(getWorkspace).not.toHaveBeenCalled();
+    expect(registerRepoUrl).not.toHaveBeenCalled();
+    expect(ensureRepo).not.toHaveBeenCalled();
+    expect(writeAndPush).not.toHaveBeenCalled();
+  });
+});

--- a/packages/gateway/src/services/workflow-writeback.ts
+++ b/packages/gateway/src/services/workflow-writeback.ts
@@ -1,0 +1,62 @@
+import { getWorkspace } from "../db/queries";
+import { ensureRepo, registerRepoUrl, writeAndPush } from "./git";
+
+function safeParseRepos(raw: string): Record<string, string> {
+  try {
+    return JSON.parse(raw || "{}") as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+export interface WorkflowWritebackInput {
+  workspaceId: number | string;
+  relativePath: string;
+  content: string;
+}
+
+export interface WorkflowWritebackDeps {
+  getWorkspace: typeof getWorkspace;
+  registerRepoUrl: typeof registerRepoUrl;
+  ensureRepo: typeof ensureRepo;
+  writeAndPush: typeof writeAndPush;
+}
+
+export function createWorkflowWritebackService(
+  deps: WorkflowWritebackDeps = {
+    getWorkspace,
+    registerRepoUrl,
+    ensureRepo,
+    writeAndPush,
+  },
+) {
+  return {
+    async writeDoc(input: WorkflowWritebackInput): Promise<void> {
+      const relativePath = input.relativePath?.trim();
+      if (!relativePath) {
+        throw new Error("relativePath is required");
+      }
+
+      const workspaceId = Number(input.workspaceId);
+      if (!Number.isFinite(workspaceId) || workspaceId <= 0) {
+        throw new Error("workspaceId is required");
+      }
+
+      const workspace = deps.getWorkspace(workspaceId);
+      if (!workspace) {
+        throw new Error(`workspace ${workspaceId} not found`);
+      }
+
+      const repos = safeParseRepos(workspace.git_repos);
+      const docsRepoUrl = repos.docs;
+      if (!docsRepoUrl) {
+        throw new Error(`workspace ${workspaceId} docs repo is not configured`);
+      }
+
+      const repoName = `ws-${workspaceId}-docs`;
+      deps.registerRepoUrl(repoName, docsRepoUrl);
+      await deps.ensureRepo(repoName);
+      await deps.writeAndPush(repoName, relativePath, input.content, `docs: write ${relativePath}`);
+    },
+  };
+}

--- a/setup/.env.example
+++ b/setup/.env.example
@@ -7,25 +7,13 @@
 GATEWAY_PORT=3100
 SSH_KEY_DIR=~/.ssh
 
-# === Dify ===
-DIFY_WEB_PORT=3001
-DIFY_DB_USER=dify
-DIFY_DB_PASSWORD=changeme-dify-db
-DIFY_DB_NAME=dify
-DIFY_SECRET_KEY=changeme-dify-secret
-DIFY_API_KEY=
-# 各工作流独立 API Key（可选）
-# DIFY_TECH_DOC_API_KEY=
-# DIFY_OPENAPI_API_KEY=
-# DIFY_BUG_ANALYSIS_API_KEY=
-
 # === Plane（独立部署，见 setup/plane/docker-compose.yml）===
 PLANE_BASE_URL=http://172.29.230.21:8082
+PLANE_EXTERNAL_URL=http://172.29.230.21:8082
 PLANE_API_TOKEN=
 PLANE_WORKSPACE_SLUG=arcflow
-
-# === Weaviate ===
-WEAVIATE_PORT=8080
+PLANE_APPROVED_STATE_ID=
+PLANE_DEFAULT_PROJECT_ID=
 
 # === Git 仓库（SSH 地址）===
 DOCS_GIT_REPO=git@github.com:ssyamv/arcflow-docs.git
@@ -38,6 +26,7 @@ ANDROID_GIT_REPO=git@github.com:ssyamv/arcflow-android.git
 PLANE_WEBHOOK_SECRET=
 GIT_WEBHOOK_SECRET=
 CICD_WEBHOOK_SECRET=
+NANOCLAW_DISPATCH_SECRET=
 
 # === 飞书（私有化部署改为内部域名，如 https://open.xfchat.iflytek.com）===
 FEISHU_BASE_URL=https://open.feishu.cn
@@ -47,5 +36,29 @@ FEISHU_VERIFICATION_TOKEN=
 FEISHU_ENCRYPT_KEY=
 FEISHU_DEFAULT_CHAT_ID=
 
+# === Web / OAuth ===
+WEB_BASE_URL=http://localhost
+OAUTH_REDIRECT_URI=http://localhost:5173/auth/callback
+JWT_SECRET=arcflow-dev-secret
+JWT_EXPIRES_IN=7d
+
 # === Claude Code ===
 CLAUDE_CODE_TIMEOUT=600000
+
+# === RAG / Embedding ===
+SILICONFLOW_API_KEY=
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1
+RAG_DB_PATH=/app/data/rag.db
+RAG_EMBEDDING_MODEL=BAAI/bge-m3
+RAG_EMBEDDING_DIM=1024
+RAG_SYNC_INTERVAL_MS=300000
+RAG_GIT_ROOT=
+RAG_WORKSPACE_ID=
+
+# === iBuild（可选）===
+IBUILD_BASE_URL=http://console.devops.iflytek.com
+IBUILD_CLIENT_KEY=
+IBUILD_USER=
+IBUILD_WEBHOOK_SECRET=
+IBUILD_APP_REPO_MAP={"default":"backend"}
+IBUILD_APP_WORKSPACE_MAP={}

--- a/setup/deploy.sh
+++ b/setup/deploy.sh
@@ -48,15 +48,17 @@ main() {
   case "$action" in
     up)
       init_env
-      log "启动 ArcFlow Gateway 独立栈..."
+      log "启动 ArcFlow 本仓核心服务栈（Gateway + Web）..."
       docker compose up -d --build
       log "等待服务就绪..."
       sleep 5
       docker compose ps
       log "部署完成！"
       log "  Gateway:  http://localhost:${GATEWAY_PORT:-3100}/health"
+      log "  Web:      http://localhost:${WEB_PORT:-80}"
       log "  Plane:    独立部署，见 setup/plane/docker-compose.yml"
       log "  NanoClaw: 服务器 PM2 进程 arcflow-nanoclaw"
+      log "  Docs:     通过工作空间配置的 docs Git 仓库提供"
       ;;
     down)
       log "停止所有服务..."

--- a/setup/deploy.test.ts
+++ b/setup/deploy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const SCRIPT = join(process.cwd(), "deploy.sh");
+
+function makeFakeSshDir() {
+  const dir = mkdtempSync(join(tmpdir(), "arcflow-deploy-test-"));
+  const logPath = join(dir, "ssh.log");
+  const sshPath = join(dir, "ssh");
+
+  writeFileSync(logPath, "");
+
+  writeFileSync(
+    sshPath,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "${logPath}"
+if [[ "$*" == *"curl -sf http://127.0.0.1:3100/health"* ]]; then
+  printf '{"status":"ok"}'
+fi
+`,
+  );
+  chmodSync(sshPath, 0o755);
+
+  return { dir, logPath };
+}
+
+async function runDeploy(args: string[]) {
+  const fake = makeFakeSshDir();
+  const proc = Bun.spawn(["bash", SCRIPT, ...args], {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      PATH: `${fake.dir}:${process.env.PATH ?? ""}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  const sshLog = readFileSync(fake.logPath, "utf8");
+
+  rmSync(fake.dir, { recursive: true, force: true });
+
+  return { exitCode, stdout, stderr, sshLog };
+}
+
+describe("deploy.sh", () => {
+  it("runs status against the trusted ArcFlow directory", async () => {
+    const result = await runDeploy(["status"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.sshLog).toContain("cd /data/project/arcflow && docker compose ps");
+  });
+
+  it("runs verify with gateway, web, and nanoclaw checks", async () => {
+    const result = await runDeploy(["verify"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.sshLog).toContain("curl -sf http://127.0.0.1:3100/health");
+    expect(result.sshLog).toContain("curl -I -sf http://127.0.0.1");
+    expect(result.sshLog).toContain("pm2 describe arcflow-nanoclaw");
+  });
+
+  it("fails rollback without a git ref", async () => {
+    const result = await runDeploy(["rollback"]);
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("用法");
+  });
+
+  it("runs drift inspection for arcflow and nanoclaw paths", async () => {
+    const result = await runDeploy(["drift"]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.sshLog).toContain("pm2 describe arcflow-nanoclaw");
+    expect(result.sshLog).toContain(
+      "cd /data/project/arcflow && git rev-parse --is-inside-work-tree",
+    );
+    expect(result.sshLog).toContain(
+      "cd /data/project/nanoclaw && git rev-parse --is-inside-work-tree",
+    );
+    expect(result.sshLog).toContain(
+      "cd /data/project/nanoclaw-fork",
+    );
+    expect(result.sshLog).toContain("git status --short");
+  });
+});

--- a/setup/gateway/.env.example
+++ b/setup/gateway/.env.example
@@ -1,20 +1,14 @@
 # === Gateway 服务配置 ===
 PORT=3100
 
-# Dify（指向 arcflow-dify-api 容器）
-DIFY_BASE_URL=http://arcflow-dify-api:5001
-DIFY_API_KEY=
-# 各工作流独立 API Key（可选，未设置时回退到 DIFY_API_KEY）
-# DIFY_TECH_DOC_API_KEY=
-# DIFY_OPENAPI_API_KEY=
-# DIFY_BUG_ANALYSIS_API_KEY=
-
 # Plane（指向 arcflow-plane-api 容器）
 PLANE_BASE_URL=http://arcflow-plane-api:8000
 # 用户浏览器可访问的 Plane 地址（飞书卡片跳转用），未设置则回退到 PLANE_BASE_URL
 PLANE_EXTERNAL_URL=http://172.29.230.21:8082
 PLANE_API_TOKEN=
 PLANE_WORKSPACE_SLUG=arcflow
+PLANE_APPROVED_STATE_ID=
+PLANE_DEFAULT_PROJECT_ID=
 
 # Git 仓库（SSH 地址）
 DOCS_GIT_REPO=git@github.com:ssyamv/arcflow-docs.git
@@ -34,6 +28,7 @@ RAG_WORKSPACE_ID=
 PLANE_WEBHOOK_SECRET=
 GIT_WEBHOOK_SECRET=
 CICD_WEBHOOK_SECRET=
+NANOCLAW_DISPATCH_SECRET=
 
 # 飞书（私有化部署改为内部域名，如 https://open.xfchat.iflytek.com）
 FEISHU_BASE_URL=https://open.feishu.cn
@@ -43,10 +38,18 @@ FEISHU_VERIFICATION_TOKEN=
 FEISHU_ENCRYPT_KEY=
 FEISHU_DEFAULT_CHAT_ID=
 
+# Web / OAuth
+WEB_BASE_URL=http://localhost
+OAUTH_REDIRECT_URI=http://localhost:5173/auth/callback
+JWT_SECRET=arcflow-dev-secret
+JWT_EXPIRES_IN=7d
+
 # Claude Code
 CLAUDE_CODE_TIMEOUT=600000
 
 # Gateway RAG
+SILICONFLOW_API_KEY=
+SILICONFLOW_BASE_URL=https://api.siliconflow.cn/v1
 RAG_DB_PATH=/app/data/rag.db
 RAG_EMBEDDING_MODEL=BAAI/bge-m3
 RAG_EMBEDDING_DIM=1024
@@ -58,6 +61,4 @@ IBUILD_CLIENT_KEY=
 IBUILD_USER=
 IBUILD_WEBHOOK_SECRET=
 IBUILD_APP_REPO_MAP={"default":"backend"}
-
-# Plane (default project for iBuild-triggered workflows)
-PLANE_DEFAULT_PROJECT_ID=
+IBUILD_APP_WORKSPACE_MAP={}

--- a/setup/nanoclaw/README.md
+++ b/setup/nanoclaw/README.md
@@ -28,8 +28,9 @@ cp .env.example .env
 # - FEISHU_APP_ID / FEISHU_APP_SECRET（飞书开放平台获取）
 # - FEISHU_WEBHOOK_PORT（默认 3000）
 # - PLANE_API_TOKEN / PLANE_BASE_URL / PLANE_WORKSPACE_SLUG
-# - GATEWAY_URL（胶水服务地址，如 http://172.29.230.21:8080）
-# - DIFY_URL / DIFY_API_KEY
+# - GATEWAY_URL（ArcFlow Gateway 地址，如 http://172.29.230.21:3100）
+# - SYSTEM_SECRET（与 Gateway `NANOCLAW_DISPATCH_SECRET` 保持一致，用于 dispatch / callback 鉴权）
+# - ArcFlow skill 所需的 Gateway / Plane / Feishu 相关配置
 ```
 
 ### 3. 构建容器镜像
@@ -77,6 +78,22 @@ npx tsx setup/index.ts --step register -- \
 
 在飞书中发送消息给机器人，检查是否收到回复。
 
+如需验证 ArcFlow 自动化链路，而不仅仅是聊天入口，至少补充检查：
+
+```bash
+curl http://<gateway-host>:3100/health
+curl -H "X-System-Secret: <system-secret>" \
+  -H "Content-Type: application/json" \
+  -d '{"workspace_id":"default","q":"health check"}' \
+  "http://<gateway-host>:3100/api/rag/search"
+```
+
+非交互 skill 完成后，应通过相同的 `X-System-Secret` 回调：
+
+```text
+POST {GATEWAY_URL}/api/workflow/callback
+```
+
 ## 更新
 
 从上游同步更新：
@@ -90,3 +107,4 @@ claude
 
 - 设计规格：`docs/superpowers/specs/2026-04-07-nanoclaw-setup-design.md`
 - 意图路由设计：`docs/superpowers/specs/2026-04-02-nanoclaw-routing-design.md`
+- 生产稳定性验证：`docs/superpowers/reports/2026-04-17-deployment-alignment-and-nanoclaw-stability-verification.md`

--- a/setup/production-runbook.md
+++ b/setup/production-runbook.md
@@ -1,0 +1,155 @@
+# ArcFlow 生产部署 Runbook
+
+> 日期：2026-04-20
+> 适用范围：ArcFlow 当前生产部署口径
+> 当前目标：先统一可信路径、更新入口、回滚入口和最小验证动作
+
+## 1. 单一可信路径
+
+当前生产口径固定为：
+
+- ArcFlow 仓库与运行目录：`/data/project/arcflow`
+- NanoClaw 仓库与运行目录：`/data/project/nanoclaw`
+- NanoClaw PM2 进程名：`arcflow-nanoclaw`
+
+历史漂移目录：
+
+- `/data/project/nanoclaw-fork`
+
+说明：
+
+- 该目录只用于解释历史验证报告中出现的“git 跟踪目录与真实运行目录不一致”问题。
+- 从当前口径开始，它不是可信运行路径，也不应作为日常发布、排障、验证的默认入口。
+
+## 2. 日常更新
+
+ArcFlow 本仓统一使用根目录脚本：
+
+```bash
+./deploy.sh up main
+```
+
+该命令会在服务器上执行：
+
+1. 同步 `ArcFlow` 仓库到 `/data/project/arcflow`
+2. 检查 `packages/gateway/.env`
+3. 运行 `docker compose build --no-cache`
+4. 运行 `docker compose up -d`
+5. 复用最小验证入口确认 Web / Gateway / NanoClaw 状态
+
+仅同步代码、不重启服务时：
+
+```bash
+./deploy.sh sync main
+```
+
+## 3. 状态检查
+
+查看 ArcFlow 本仓容器状态：
+
+```bash
+./deploy.sh status
+```
+
+该命令只检查 `/data/project/arcflow` 下的 Docker Compose 栈。
+
+## 4. 运行漂移检查
+
+检查 ArcFlow / NanoClaw 当前运行路径与 git 跟踪路径是否一致：
+
+```bash
+./deploy.sh drift
+```
+
+当前该命令会检查：
+
+- `pm2 describe arcflow-nanoclaw`
+- `/data/project/arcflow` 是否是 git 仓库
+- `/data/project/nanoclaw` 是否是 git 仓库
+- `/data/project/nanoclaw-fork` 是否存在以及是否有未提交改动
+
+截至 `2026-04-20` 收口后的当前事实：
+
+- `/data/project/nanoclaw` 是当前 PM2 运行目录
+- `/data/project/nanoclaw` 已补齐为 git 仓库
+- 历史漂移目录已归档为：
+  - `/data/project/nanoclaw-fork.backup-20260420-173251`
+
+说明：
+
+- 当前默认排障路径不再使用 `/data/project/nanoclaw-fork`
+- 如需追溯历史服务器工作区，可查看上述 backup 目录
+
+## 5. 最小验证
+
+每次更新后至少执行：
+
+```bash
+./deploy.sh verify
+```
+
+当前最小验证动作包括：
+
+- `cd /data/project/arcflow && docker compose ps`
+- `curl -sf http://127.0.0.1:3100/health`
+- `curl -I -sf http://127.0.0.1`
+- `pm2 describe arcflow-nanoclaw`
+
+说明：
+
+- 这不是完整业务验收。
+- 它只负责确认当前“ArcFlow 容器栈 + NanoClaw 进程”处于可排障、可继续联调的状态。
+
+## 6. 回滚
+
+ArcFlow 本仓回滚统一使用：
+
+```bash
+./deploy.sh rollback <git-ref>
+```
+
+示例：
+
+```bash
+./deploy.sh rollback 3d857ef19ba5e4f16e4357bd840461c4fcef1fec
+```
+
+该命令会：
+
+1. 在 `/data/project/arcflow` 执行 `git fetch --all --tags`
+2. `git checkout <git-ref>`
+3. 重新 `docker compose build --no-cache`
+4. 重新 `docker compose up -d`
+5. 自动执行最小验证
+
+限制：
+
+- 当前只回滚 ArcFlow 本仓，不隐式回滚 NanoClaw 独立仓。
+- NanoClaw 如需回滚，必须在 `/data/project/nanoclaw` 独立执行对应 git / build / pm2 操作，并单独记录。
+
+## 7. NanoClaw 独立操作边界
+
+NanoClaw 仍是独立仓、独立发布，不纳入本仓 Docker Compose。
+
+当前可信操作入口：
+
+```bash
+ssh arcflow-server
+cd /data/project/nanoclaw
+pm2 describe arcflow-nanoclaw
+```
+
+不要把以下动作混入 ArcFlow 本仓回滚脚本：
+
+- NanoClaw 的 git checkout
+- NanoClaw 的 npm install / npm run build
+- NanoClaw 的 PM2 reload 策略变更
+
+这些动作仍然属于 NanoClaw 独立仓运维范围。
+
+## 8. 剩余缺口
+
+本 runbook 只关闭了“部署口径统一”的第一步，尚未完全消除服务器上的历史漂移。后续仍需继续收口：
+
+- NanoClaw 运行目录虽然已经成为 git 仓库，但当前仍是 dirty worktree
+- NanoClaw 独立仓是否需要补自己的标准化回滚/验证脚本


### PR DESCRIPTION
## Summary
- close ArcFlow P0 callback writeback gaps with real docs repo writes, Plane comments, and strict callback-contract coverage
- add production deployment alignment artifacts for P1-4, including `deploy.sh` subcommands, drift inspection, runbook updates, and backlog updates
- capture current-state specs/plans and verification docs that match the implemented Gateway and deployment flow

## Validation
- `bun test packages/gateway/src/services/workflow-writeback.test.ts packages/gateway/src/services/plane.test.ts packages/gateway/src/services/workflow-callback.test.ts packages/gateway/src/index.test.ts setup/deploy.test.ts`
- `bunx markdownlint-cli2 "docs/**/*.md" "setup/**/*.md"`
- `bash ./deploy.sh drift`
- `bash ./deploy.sh verify`

## Notes
- production NanoClaw runtime drift was reduced on the server so `/data/project/nanoclaw` is now the default runtime path and the old `nanoclaw-fork` path was archived
- this PR keeps P1-4 open in the backlog because NanoClaw still needs its own standardized deploy/rollback entrypoints in the independent repo